### PR TITLE
Fix crash on non-constant and dynamic-constant-path superclasses

### DIFF
--- a/lib/archspec/analyzer.rb
+++ b/lib/archspec/analyzer.rb
@@ -196,8 +196,7 @@ module ArchSpec
           location: SourceLocation.from_prism(path, node.location)
         )
 
-        if node.superclass
-          superclass = constant_reference_name(node.superclass)
+        if node.superclass && (superclass = constant_reference_name(node.superclass))
           constant.superclass = superclass
           graph.add_edge(
             type: :inherits_from,
@@ -318,11 +317,14 @@ module ArchSpec
       end
 
       def add_constant_reference(graph, path, node, current_constant)
+        name = constant_reference_name(node)
+        return unless name
+
         graph.add_edge(
           type: :references_constant,
           from_path: path,
           from_constant: current_constant,
-          to: constant_reference_name(node),
+          to: name,
           location: SourceLocation.from_prism(path, node.location)
         )
       end
@@ -369,7 +371,12 @@ module ArchSpec
       end
 
       def constant_reference_name(node)
+        return unless constant_node?(node)
+
         node.full_name.to_s.sub(/\A::/, '')
+      rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
+             Prism::ConstantPathNode::MissingNodesInConstantPathError
+        nil
       end
 
       def constant_node?(node)

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -71,4 +71,43 @@ class AnalyzerTest < ArchSpecTest
       assert_equal 'Chargeable', file.expected_constant
     end
   end
+
+  def test_handles_non_constant_and_dynamic_superclasses
+    with_project do |root|
+      write "#{root}/app/models/money.rb", <<~RUBY
+        class Money < Data.define(:cents)
+        end
+      RUBY
+
+      write "#{root}/app/models/result.rb", <<~RUBY
+        class Result < Struct.new(:ok)
+        end
+      RUBY
+
+      write "#{root}/app/models/widget.rb", <<~RUBY
+        class Widget < Object.const_get("ApplicationRecord")
+        end
+      RUBY
+
+      write "#{root}/app/models/thing.rb", <<~RUBY
+        class Thing < foo::Bar
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :models, in: 'app/models/**/*.rb'
+      end
+
+      # A method-call superclass (Data.define/Struct.new/const_get) is a
+      # Prism::CallNode and a dynamic constant path (foo::Bar) raises from
+      # #full_name -- neither should crash the analyzer.
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+
+      assert_equal %w[Money Result Thing Widget], graph.constants.map(&:name).sort
+      refute(
+        graph.edges.any? { |edge| edge.type == :inherits_from },
+        'non-constant / dynamic superclasses must not produce inherits_from edges'
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`archspec check` crashes on any class whose **superclass is a method call** or a **dynamic constant path**, aborting the entire scan. A single such class makes archspec unusable on the project.

Minimal repro:

```ruby
# money.rb
class Money < Data.define(:cents); end
```
```ruby
# Archspec.rb
source "money.rb"
```
```
$ archspec check
.../archspec/analyzer.rb:372:in 'constant_reference_name':
  undefined method 'full_name' for an instance of Prism::CallNode (NoMethodError)
```

`Data.define(...)`, `Struct.new(...)` and `Object.const_get("X")` all parse as `Prism::CallNode` superclasses. A dynamic constant path (`class Foo < bar::Baz`) reaches the same line and raises `Prism::ConstantPathNode::DynamicPartsInConstantPathError`. Both are valid, common Ruby (Data/Struct value objects especially), so one occurrence stops a whole-project scan.

## Cause

`Analyzer::SourceVisitor#constant_reference_name` calls `node.full_name` unconditionally; that method only exists on `ConstantReadNode` / `ConstantPathNode`.

## Fix

- Guard `constant_reference_name` with the existing `constant_node?` predicate and rescue Prism's dynamic-path errors, returning `nil` for un-nameable references.
- The two edge builders (`inherits_from`, `references_constant`) skip the edge when the name is `nil`. Class/module **name** resolution is unaffected — those paths are always static constants.

## Tests

- New `test_handles_non_constant_and_dynamic_superclasses` covering `Data.define`, `Struct.new`, `Object.const_get`, and a dynamic `foo::Bar` superclass. It errors without the fix.
- Full suite green (`rake test`); `rake architecture` dogfood green; syntax check green.
- Verified end-to-end against a real ~1,800-file engine tree that previously crashed — now completes.
