### PR TITLE
Ignore namespace-only class reopening when tracking constants

### DIFF
--- a/lib/archspec/analyzer.rb
+++ b/lib/archspec/analyzer.rb
@@ -209,7 +209,8 @@ module ArchSpec
           kind: :class,
           path: path,
           location: SourceLocation.from_prism(path, node.location),
-          nesting: nesting
+          nesting: nesting,
+          namespace_only: node.superclass.nil? && namespace_only_body?(node.body)
         )
 
         if node.superclass
@@ -249,7 +250,8 @@ module ArchSpec
           kind: :module,
           path: path,
           location: SourceLocation.from_prism(path, node.location),
-          nesting: nesting
+          nesting: nesting,
+          namespace_only: namespace_only_body?(node.body)
         )
 
         visit_constant_body(graph, path, constant, node.body, constant.name.split('::'),
@@ -286,6 +288,12 @@ module ArchSpec
         else
           visit(graph, path, node.value, current_constant: constant.name, namespace: namespace, nesting: nesting)
         end
+      end
+
+      def namespace_only_body?(body)
+        body.is_a?(Prism::StatementsNode) &&
+          !body.body.empty? &&
+          body.body.all? { |child| child.is_a?(Prism::ClassNode) || child.is_a?(Prism::ModuleNode) }
       end
 
       def assigned_constant_name(node, namespace)

--- a/lib/archspec/model.rb
+++ b/lib/archspec/model.rb
@@ -31,13 +31,14 @@ module ArchSpec
   class ConstantNode
     attr_reader :name, :kind, :path, :location, :instance_methods, :class_methods, :method_definitions, :mixins,
                 :nesting
-    attr_accessor :superclass
+    attr_accessor :superclass, :namespace_only
 
-    def initialize(name:, kind:, path:, location:, nesting: [])
+    def initialize(name:, kind:, path:, location:, nesting: [], namespace_only: false)
       @name = name
       @kind = kind
       @path = path
       @location = location
+      @namespace_only = namespace_only
       @nesting = Array(nesting).dup.freeze
       @instance_methods = Set.new
       @class_methods = Set.new
@@ -171,12 +172,16 @@ module ArchSpec
       )
     end
 
-    def add_constant(name:, kind:, path:, location:, nesting: [])
+    def add_constant(name:, kind:, path:, location:, nesting: [], namespace_only: false)
       normalized = normalize_constant(name)
       existing = @constants_by_name[normalized].find { |constant| constant.path == path && constant.kind == kind }
-      return existing if existing
+      if existing
+        existing.namespace_only &&= namespace_only
+        return existing
+      end
 
-      constant = ConstantNode.new(name: normalized, kind: kind, path: path, location: location, nesting: nesting)
+      constant = ConstantNode.new(name: normalized, kind: kind, path: path, location: location, nesting: nesting,
+                                  namespace_only: namespace_only)
       constants << constant
       @constants_by_name[normalized] << constant
       constant
@@ -224,7 +229,7 @@ module ArchSpec
         end
 
         constants.each do |constant|
-          matched_file = files_matched_by_pattern.include?(constant.path)
+          matched_file = files_matched_by_pattern.include?(constant.path) && !defers_to_real_definition?(constant)
           matched_constant = spec.matches_constant?(constant.name)
           next unless matched_file || matched_constant
 
@@ -372,6 +377,11 @@ module ArchSpec
     end
 
     private
+
+    def defers_to_real_definition?(constant)
+      constant.namespace_only &&
+        @constants_by_name[constant.name].any? { |other| !other.namespace_only }
+    end
 
     def each_matching_file(pattern)
       glob = File.absolute_path(pattern, root)

--- a/test/rules_test.rb
+++ b/test/rules_test.rb
@@ -808,4 +808,68 @@ class RulesTest < ArchSpecTest
 
     assert_match(/no_cycles references unknown component: controlers/, error.message)
   end
+
+  def test_namespace_only_reopenings_do_not_claim_the_constant
+    with_project do |root|
+      write "#{root}/app/models/project.rb", <<~RUBY
+        class Project
+          def active? = true
+        end
+      RUBY
+
+      write "#{root}/app/jobs/project/expiration_job.rb", <<~RUBY
+        class Project
+          class ExpirationJob
+            def perform = nil
+          end
+        end
+      RUBY
+
+      write "#{root}/app/services/project_archiver.rb", <<~RUBY
+        class ProjectArchiver
+          def call
+            Project.new
+          end
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :models, in: 'app/models/**/*.rb'
+        component :jobs, in: 'app/jobs/**/*.rb'
+        component :services, in: 'app/services/**/*.rb'
+        services.can_only_use :models
+      end
+
+      assert_empty diagnostics_for(definition, root)
+    end
+  end
+
+  def test_namespace_without_real_definition_still_belongs_to_its_component
+    with_project do |root|
+      write "#{root}/app/services/payments/charge.rb", <<~RUBY
+        module Payments
+          class Charge
+            def call = nil
+          end
+        end
+      RUBY
+
+      write "#{root}/app/models/invoice.rb", <<~RUBY
+        class Invoice
+          Payments
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :models, in: 'app/models/**/*.rb'
+        component :services, in: 'app/services/**/*.rb'
+        models.cannot_use :services
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_match(/models must not depend on services/, diagnostics.first.message)
+    end
+  end
 end


### PR DESCRIPTION
The following code should not make Project a job / service layer / whatever; it must stay a model, here it iss just a namespace:

```ruby
# app/jobs/project/archive_job.rb
class Project
  class ArchiveJob
    def perform = nil
  end
end
```

It's a common pattern to namespace dependent objects (jobs, services, whatever) under the model class, and currently `archspec` sees a class declared in, say, `app/jobs` and thinks it's now a job, too.

This PR adds a check (`#namespace_only_body?(body)`) that let the analyze ignore the namespace-only reopening.

That should work in most cases but still I can imaging situations when there could be something else within the body (a constant? some DSL?) that would break the check. I'd consider adding some annotation in the future to ignore the  location completely from the analysis (do not add it to the analyzer's graph)