### PR TITLE
Add can_also_use to provide additional grants to components

### DIFF
--- a/lib/archspec/analyzer.rb
+++ b/lib/archspec/analyzer.rb
@@ -22,6 +22,7 @@ module ArchSpec
       end
 
       graph.assign_components(definition.component_specs.values)
+      graph.grants = definition.grants
       graph
     end
 

--- a/lib/archspec/definition.rb
+++ b/lib/archspec/definition.rb
@@ -22,7 +22,7 @@ module ArchSpec
     ].freeze
 
     attr_accessor :name, :root_path, :todo_path, :base_dir
-    attr_reader :source_patterns, :ignore_patterns, :component_specs, :rules
+    attr_reader :source_patterns, :ignore_patterns, :component_specs, :rules, :grants
 
     def initialize(name = nil)
       @name = name
@@ -33,6 +33,11 @@ module ArchSpec
       @ignore_patterns = DEFAULT_IGNORE_PATTERNS.dup
       @component_specs = {}
       @rules = []
+      @grants = {}
+    end
+
+    def add_grant(source, targets)
+      (@grants[source.to_sym] ||= Set.new).merge(Array(targets).flatten.map(&:to_sym))
     end
 
     def add_source_patterns(patterns)

--- a/lib/archspec/dsl.rb
+++ b/lib/archspec/dsl.rb
@@ -178,6 +178,18 @@ module ArchSpec
         self
       end
 
+      # Grants extra allowed targets to this component on top of any allowlist,
+      # including allowlists of other components sharing its files. Use it to
+      # give a nested component an escape hatch from its enclosing layer.
+      # Does not override #cannot_use.
+      #
+      #   workflows.can_also_use :notifications
+      def can_also_use(*targets)
+        DSL.assert_known_components!(definition, targets, for_rule: "#{name}.can_also_use")
+        definition.add_grant(name, targets)
+        self
+      end
+
       # Forbids depending on the named components. Narrower than #can_only_use:
       # only the listed components fail, other dependencies are left alone.
       #

--- a/lib/archspec/model.rb
+++ b/lib/archspec/model.rb
@@ -152,6 +152,7 @@ module ArchSpec
     RESOLVED_ROOTS = %w[Object BasicObject].freeze
 
     attr_reader :root, :files, :constants, :edges, :components
+    attr_accessor :grants
 
     def initialize(root)
       @root = File.expand_path(root)
@@ -160,6 +161,11 @@ module ArchSpec
       @constants_by_name = Hash.new { |hash, key| hash[key] = [] }
       @edges = []
       @components = {}
+      @grants = {}
+    end
+
+    def granted?(edge, target)
+      source_components_for(edge).any? { |component| grants[component]&.include?(target) }
     end
 
     def add_file(path:, parse_errors:, suppressions: [])

--- a/lib/archspec/rules/dependency_rules.rb
+++ b/lib/archspec/rules/dependency_rules.rb
@@ -43,7 +43,7 @@ module ArchSpec
       def evaluate(graph)
         relevant_edges(graph).flat_map do |edge|
           graph.target_components_for(edge).filter_map do |target|
-            next if target == source || targets.include?(target)
+            next if target == source || targets.include?(target) || graph.granted?(edge, target)
 
             Diagnostic.new(
               rule: id,

--- a/test/rules_test.rb
+++ b/test/rules_test.rb
@@ -670,4 +670,40 @@ class RulesTest < ArchSpecTest
 
     assert_match(/no_cycles references unknown component: controlers/, error.message)
   end
+
+  def test_can_also_use_grants_extra_targets
+    with_project do |root|
+      write "#{root}/app/models/order.rb", <<~RUBY
+        class Order
+          def notify = OrderMailer
+        end
+      RUBY
+
+      write "#{root}/app/models/order_workflow.rb", <<~RUBY
+        class OrderWorkflow
+          def finish = OrderMailer
+        end
+      RUBY
+
+      write "#{root}/app/mailers/order_mailer.rb", <<~RUBY
+        class OrderMailer
+          def deliver = nil
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :models, in: 'app/models/**/*.rb'
+        component :workflows, in: 'app/models/**/*_workflow.rb'
+        component :mailers, in: 'app/mailers/**/*.rb'
+        models.can_only_use :workflows
+        workflows.can_also_use :mailers
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_match(/models may not depend on mailers/, diagnostics.first.message)
+      assert_match(/Order references OrderMailer/, diagnostics.first.evidence)
+    end
+  end
 end


### PR DESCRIPTION
Let's be flexible and allow having conventional hatches between layers.

My example:

I have domain-level workflows (kinda standalone state-machines) as domain services (i.e., in app/models) with some additional privileges, like triggering notifications. In other words, the domain layer has two tiers: domain objects and domain services. Currently, it's impossible to separate at Archspec level: there is no glob exclusion in a component definition.

With this feature, my config becomes like this:

```rb
architecture :layered, layers: {
  # ...
  domain: %w[
    app/models/**/*.rb
  ]
}


component :notifications, in: %w[app/mailers/**/*.rb app/deliveries/**/*.rb]
# ...
component :workflows, in: %w[app/models/**/*_workflow.rb app/models/**/workflow.rb]
workflows.can_also_use :notifications
# ...
```

Thus, workflows inherit `domain` boundaries and extend them a bit.

A workaround is to add `app/workflows`—I don't really like it, 'cause it deludes the whole hierarchy and breaks cohesion.