### PR TITLE
Let components exclude files and protocols check the class side

### DIFF
--- a/docs/_reference/configuration.md
+++ b/docs/_reference/configuration.md
@@ -29,7 +29,7 @@ component :domain,      in: "app/models/**/*.rb", except: "app/models/**/*_workf
 component :workflows,   in: "app/models/**/*_workflow.rb"
 ```
 
-`except:` removes files from what `in:` matched. A few files that need wider grants than their layer become their own component with their own allowlist, instead of a hole in the layer's. The same keyword works inside the hash form every architecture accepts, so a layer in `layers:` can read `{ in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb" }`.
+`except:` removes files from what `in:` matched, and only those: a file the component also claims through `namespace:` or `constants:` stays a member. A component with `except:` and no `in:` is an error. A few files that need wider grants than their layer become their own component with their own allowlist, instead of a hole in the layer's. The same keyword works inside the hash form every architecture accepts, so a layer in `layers:` can read `{ in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb" }`.
 
 Declare one component per subdirectory with `each_directory`, which is handy for engines and packs:
 

--- a/docs/_reference/configuration.md
+++ b/docs/_reference/configuration.md
@@ -25,7 +25,11 @@ Todo ids are computed from the rule, path, message, and evidence, not the line n
 component :controllers, in: "app/controllers/**/*.rb"
 component :models,      in: "app/models/**/*.rb"
 component :billing,     namespace: "Billing"
+component :domain,      in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb"
+component :workflows,   in: "app/models/**/*_workflow.rb"
 ```
+
+`except:` removes files from what `in:` matched. A few files that need wider grants than their layer become their own component with their own allowlist, instead of a hole in the layer's. The same keyword works inside the hash form every architecture accepts, so a layer in `layers:` can read `{ in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb" }`.
 
 Declare one component per subdirectory with `each_directory`, which is handy for engines and packs:
 

--- a/docs/_rules/protocols.md
+++ b/docs/_rules/protocols.md
@@ -6,7 +6,7 @@ description: Use ArchSpec protocol rules to require classes in a component to im
 
 # Protocols
 
-Protocol rules check that classes in a component define expected instance methods.
+Protocol rules check that classes in a component define expected methods. Instance methods by default; pass `scope: :class` for a class-side protocol.
 
 ## Require One Method
 
@@ -23,5 +23,13 @@ queries.must_implement_one_of :call, :resolve
 ```
 
 Rule id: `protocol.must_implement_one_of`
+
+## Class-Side Protocols
+
+```ruby
+jobs.must_implement :perform_later, scope: :class
+```
+
+With `scope: :class` the rule counts the class's own class methods, the instance methods of every module it `extend`s, and the class methods of its superclass chain. An ancestor ArchSpec cannot resolve lowers the diagnostic to medium confidence, as it does for instance protocols.
 
 These checks are intentionally simple. They verify the visible method definitions in source. They do not prove behavior.

--- a/lib/archspec/architectures.rb
+++ b/lib/archspec/architectures.rb
@@ -317,6 +317,7 @@ module ArchSpec
         dsl.component(
           name,
           in: selector[:in] || selector[:files],
+          except: selector[:except],
           namespace: selector[:namespace],
           constants: selector[:constants]
         )

--- a/lib/archspec/component_spec.rb
+++ b/lib/archspec/component_spec.rb
@@ -2,20 +2,23 @@
 
 module ArchSpec
   # How a component selects its members: by file glob, by namespace, or by
-  # explicit constant name. Created by ArchSpec::DSL::Context#component. The
-  # analyzer uses it to assign files and constants to the component.
+  # explicit constant name, minus any file an +except+ glob names. Created by
+  # ArchSpec::DSL::Context#component. The analyzer uses it to assign files and
+  # constants to the component.
   class ComponentSpec
-    attr_reader :name, :file_patterns, :namespaces, :constants
+    attr_reader :name, :file_patterns, :except_patterns, :namespaces, :constants
 
-    def initialize(name, files: [], namespace: nil, constants: nil)
+    def initialize(name, files: [], except: [], namespace: nil, constants: nil)
       @name = name.to_sym
       @file_patterns = Array(files).compact.map(&:to_s)
+      @except_patterns = Array(except).compact.map(&:to_s)
       @namespaces = Array(namespace).compact.map { |value| normalize_constant(value) }
       @constants = Array(constants).compact.map { |value| normalize_constant(value) }
     end
 
     def merge!(other)
       @file_patterns |= other.file_patterns
+      @except_patterns |= other.except_patterns
       @namespaces |= other.namespaces
       @constants |= other.constants
       self

--- a/lib/archspec/definition.rb
+++ b/lib/archspec/definition.rb
@@ -49,6 +49,10 @@ module ArchSpec
       else
         component_specs[spec.name] = spec
       end
+      merged = component_specs.fetch(spec.name)
+      return if merged.except_patterns.empty? || merged.file_patterns.any?
+
+      raise Error, "component :#{spec.name} has except: but no in: to exclude from"
     end
 
     def component?(name)

--- a/lib/archspec/dsl.rb
+++ b/lib/archspec/dsl.rb
@@ -92,14 +92,26 @@ module ArchSpec
       # or explicit constant.
       #
       #   component :services, in: "app/services/**/*.rb"
+      #   component :domain, in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb"
       #   component :billing, namespace: "Billing"
       #   component :legacy, constants: %w[OldReport OldExport]
       #
+      # +except:+ removes files from what +in:+ matched, so a handful of files
+      # can form their own component with their own rules instead of a hole in
+      # this one's allowlist. It never widens anything: the carved-out component
+      # states its own dependencies.
+      #
       # Returns an ArchSpec::DSL::ComponentProxy for attaching rules. The
       # component is also available by name later in the file.
-      def component(name, in: nil, namespace: nil, constants: nil)
+      def component(name, in: nil, except: nil, namespace: nil, constants: nil)
         add_component(
-          ComponentSpec.new(name, files: binding.local_variable_get(:in), namespace: namespace, constants: constants)
+          ComponentSpec.new(
+            name,
+            files: binding.local_variable_get(:in),
+            except: except,
+            namespace: namespace,
+            constants: constants
+          )
         )
         ComponentProxy.new(self, name)
       end
@@ -295,29 +307,33 @@ module ArchSpec
       end
 
       # Requires every class in the component to implement all the named
-      # instance methods. Methods inherited from resolvable superclasses or
-      # mixins count.
+      # methods. Methods inherited from resolvable superclasses or mixins
+      # count. Pass <tt>scope: :class</tt> for a class-side protocol, which
+      # counts class methods, methods from +extend+ed modules, and the
+      # superclass chain's class methods.
       #
       #   commands.must_implement :perform
+      #   jobs.must_implement :perform_later, scope: :class
       #
       # Rule id: +protocol.must_implement+.
-      def must_implement(*methods)
+      def must_implement(*methods, scope: :instance)
         raise Error, 'must_implement requires at least one method' if methods.flatten.compact.empty?
 
-        methods.each do |method_name|
-          add_rule(Rules::MustImplementRule.new(name, method_name))
+        methods.flatten.each do |method_name|
+          add_rule(Rules::MustImplementRule.new(name, method_name, scope: scope))
         end
         self
       end
 
       # Requires every class in the component to implement at least one of the
-      # named instance methods. Useful when a protocol allows either name.
+      # named methods. Useful when a protocol allows either name. Takes the
+      # same +scope:+ as +must_implement+.
       #
       #   commands.must_implement_one_of :perform, :call
       #
       # Rule id: +protocol.must_implement_one_of+.
-      def must_implement_one_of(*methods)
-        add_rule(Rules::MustImplementOneOfRule.new(name, methods))
+      def must_implement_one_of(*methods, scope: :instance)
+        add_rule(Rules::MustImplementOneOfRule.new(name, methods, scope: scope))
         self
       end
 

--- a/lib/archspec/dsl.rb
+++ b/lib/archspec/dsl.rb
@@ -319,7 +319,7 @@ module ArchSpec
       def must_implement(*methods, scope: :instance)
         raise Error, 'must_implement requires at least one method' if methods.flatten.compact.empty?
 
-        methods.flatten.each do |method_name|
+        methods.each do |method_name|
           add_rule(Rules::MustImplementRule.new(name, method_name, scope: scope))
         end
         self

--- a/lib/archspec/formatters/explanation.rb
+++ b/lib/archspec/formatters/explanation.rb
@@ -27,6 +27,7 @@ module ArchSpec
         output.puts "  #{style.note('defined constants:')} #{graph.constants_for_path(path).map(&:name).join(', ')}"
         print_parse_errors(output, style, file)
         print_component_reasons(output, style, graph.component_assignment_reasons_for_path(path))
+        print_component_exclusions(output, style, graph.component_exclusion_reasons_for_path(path))
         print_suppressions(output, style, file)
         print_facts(output, style, graph.edges.select { |edge| edge.from_path == path })
       end
@@ -60,6 +61,15 @@ module ArchSpec
         output.puts "  #{style.note('components:')}"
         assignments.sort_by { |name, _reasons| name.to_s }.each do |name, reasons|
           output.puts "    #{name}: #{reasons.empty? ? '(no recorded reason)' : reasons.join('; ')}"
+        end
+      end
+
+      def print_component_exclusions(output, style, exclusions)
+        return if exclusions.empty?
+
+        output.puts "  #{style.note('excluded from:')}"
+        exclusions.sort_by { |name, _reasons| name.to_s }.each do |name, reasons|
+          output.puts "    #{name}: #{reasons.join('; ')}"
         end
       end
 

--- a/lib/archspec/model.rb
+++ b/lib/archspec/model.rb
@@ -127,6 +127,16 @@ module ArchSpec
       file_reasons[path].add(reason) if reason
     end
 
+    def remove_file(path, reason: nil)
+      files.delete(path)
+      file_reasons.delete(path)
+      exclusion_reasons[path].add(reason) if reason
+    end
+
+    def exclusion_reasons
+      @exclusion_reasons ||= Hash.new { |hash, key| hash[key] = Set.new }
+    end
+
     def add_constant(name, path:, reason: nil)
       constants.add(name)
       @constant_occurrences.add([name, path])
@@ -223,6 +233,14 @@ module ArchSpec
           end
         end
 
+        spec.except_patterns.each do |pattern|
+          each_matching_file(pattern) do |path|
+            next unless files_matched_by_pattern.delete?(path)
+
+            component.remove_file(path, reason: "excluded by except pattern #{pattern}")
+          end
+        end
+
         constants.each do |constant|
           matched_file = files_matched_by_pattern.include?(constant.path)
           matched_constant = spec.matches_constant?(constant.name)
@@ -303,43 +321,23 @@ module ArchSpec
     # and include/prepend mixins. Returns [methods, unresolved ancestor names];
     # a non-empty second element means the answer is incomplete.
     def effective_instance_methods(name, visited = Set.new)
-      normalized = normalize_constant(name)
-      return [Set.new, Set.new] if visited.include?(normalized)
-
-      visited.add(normalized)
-      return [Set.new, Set.new] if RESOLVED_ROOTS.include?(normalized)
-
-      nodes = constants_named(normalized)
-      return [Set.new, Set[normalized]] if nodes.empty?
-
-      methods = Set.new
-      unresolved = Set.new
-
-      nodes.each do |node|
-        methods.merge(node.instance_methods)
-
+      effective_methods(name, visited) do |node|
         mixins = node.mixins[:include].to_a + node.mixins[:prepend].to_a
-
-        mixins.each do |ancestor|
-          resolved_name = resolve_constant_reference(
-            ancestor,
-            node.name,
-            lexical_nesting: [node.name] + node.nesting
-          )
-          ancestor_methods, ancestor_unresolved = effective_instance_methods(resolved_name, visited)
-          methods.merge(ancestor_methods)
-          unresolved.merge(ancestor_unresolved)
-        end
-
-        if node.superclass
-          resolved_name = resolve_constant_reference(node.superclass, node.name, lexical_nesting: node.nesting)
-          ancestor_methods, ancestor_unresolved = effective_instance_methods(resolved_name, visited)
-          methods.merge(ancestor_methods)
-          unresolved.merge(ancestor_unresolved)
-        end
+        [node.instance_methods, mixins.map { |ancestor| [ancestor, :instance] }, :instance]
       end
+    end
 
-      [methods, unresolved]
+    # A class's methods on the class side: its own, those of every module it
+    # +extend+s (their instance methods land on the singleton), and the class
+    # methods of its superclass chain.
+    def effective_class_methods(name, visited = Set.new)
+      effective_methods(name, visited) do |node|
+        [node.class_methods, node.mixins[:extend].to_a.map { |ancestor| [ancestor, :instance] }, :class]
+      end
+    end
+
+    def effective_methods_in_scope(name, scope)
+      scope == :class ? effective_class_methods(name) : effective_instance_methods(name)
     end
 
     def component_assignment_reasons_for_path(path)
@@ -347,6 +345,14 @@ module ArchSpec
         next unless component.files.include?(path)
 
         reasons[component.name] = component.file_reasons[path].to_a.sort
+      end
+    end
+
+    def component_exclusion_reasons_for_path(path)
+      components.values.each_with_object({}) do |component, reasons|
+        next unless component.exclusion_reasons.key?(path)
+
+        reasons[component.name] = component.exclusion_reasons[path].to_a.sort
       end
     end
 
@@ -372,6 +378,57 @@ module ArchSpec
     end
 
     private
+
+    # Walks a constant's ancestry collecting methods. The block maps a node to
+    # its own methods in the requested scope, the mixins to follow with the
+    # scope to read them in, and the scope to read the superclass chain in.
+    # Superclass resolution and the cycle guard are shared by both walks.
+    def effective_methods(name, visited, &scope_of)
+      normalized = normalize_constant(name)
+      return [Set.new, Set.new] if visited.include?(normalized)
+
+      visited.add(normalized)
+      return [Set.new, Set.new] if RESOLVED_ROOTS.include?(normalized)
+
+      nodes = constants_named(normalized)
+      return [Set.new, Set[normalized]] if nodes.empty?
+
+      methods = Set.new
+      unresolved = Set.new
+
+      nodes.each do |node|
+        own_methods, mixins, superclass_scope = yield(node)
+        methods.merge(own_methods)
+
+        mixins.each do |ancestor, scope|
+          resolved_name = resolve_constant_reference(
+            ancestor,
+            node.name,
+            lexical_nesting: [node.name] + node.nesting
+          )
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, scope, visited, &scope_of)
+          methods.merge(ancestor_methods)
+          unresolved.merge(ancestor_unresolved)
+        end
+
+        if node.superclass
+          resolved_name = resolve_constant_reference(node.superclass, node.name, lexical_nesting: node.nesting)
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, superclass_scope, visited, &scope_of)
+          methods.merge(ancestor_methods)
+          unresolved.merge(ancestor_unresolved)
+        end
+      end
+
+      [methods, unresolved]
+    end
+
+    def walk_ancestor(name, scope, visited, &scope_of)
+      if scope == :instance
+        effective_instance_methods(name, visited)
+      else
+        effective_methods(name, visited, &scope_of)
+      end
+    end
 
     def each_matching_file(pattern)
       glob = File.absolute_path(pattern, root)

--- a/lib/archspec/model.rb
+++ b/lib/archspec/model.rb
@@ -351,6 +351,7 @@ module ArchSpec
     def component_exclusion_reasons_for_path(path)
       components.values.each_with_object({}) do |component, reasons|
         next unless component.exclusion_reasons.key?(path)
+        next if component.files.include?(path)
 
         reasons[component.name] = component.exclusion_reasons[path].to_a.sort
       end
@@ -383,7 +384,7 @@ module ArchSpec
     # its own methods in the requested scope, the mixins to follow with the
     # scope to read them in, and the scope to read the superclass chain in.
     # Superclass resolution and the cycle guard are shared by both walks.
-    def effective_methods(name, visited, &scope_of)
+    def effective_methods(name, visited, &)
       normalized = normalize_constant(name)
       return [Set.new, Set.new] if visited.include?(normalized)
 
@@ -406,14 +407,14 @@ module ArchSpec
             node.name,
             lexical_nesting: [node.name] + node.nesting
           )
-          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, scope, visited, &scope_of)
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, scope, visited, &)
           methods.merge(ancestor_methods)
           unresolved.merge(ancestor_unresolved)
         end
 
         if node.superclass
           resolved_name = resolve_constant_reference(node.superclass, node.name, lexical_nesting: node.nesting)
-          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, superclass_scope, visited, &scope_of)
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, superclass_scope, visited, &)
           methods.merge(ancestor_methods)
           unresolved.merge(ancestor_unresolved)
         end
@@ -422,11 +423,11 @@ module ArchSpec
       [methods, unresolved]
     end
 
-    def walk_ancestor(name, scope, visited, &scope_of)
+    def walk_ancestor(name, scope, visited, &)
       if scope == :instance
         effective_instance_methods(name, visited)
       else
-        effective_methods(name, visited, &scope_of)
+        effective_methods(name, visited, &)
       end
     end
 

--- a/lib/archspec/rules/protocol_rules.rb
+++ b/lib/archspec/rules/protocol_rules.rb
@@ -63,15 +63,16 @@ module ArchSpec
     # component that do not implement the method, counting inherited and
     # mixed-in methods.
     class MustImplementRule
-      attr_reader :source, :method_name
+      attr_reader :source, :method_name, :scope
 
-      def initialize(source, method_name)
+      def initialize(source, method_name, scope: :instance)
         @source = source.to_sym
         @method_name = method_name.to_sym
+        @scope = ProtocolEvidence.validate_scope(scope)
       end
 
       def merge_key
-        [self.class, source, method_name]
+        [self.class, source, method_name, scope]
       end
 
       def id
@@ -80,14 +81,14 @@ module ArchSpec
 
       def evaluate(graph)
         constants_for(graph).filter_map do |constant|
-          methods, unresolved = graph.effective_instance_methods(constant.name)
+          methods, unresolved = graph.effective_methods_in_scope(constant.name, scope)
           next if methods.include?(method_name)
 
           Diagnostic.new(
             rule: id,
-            message: "#{constant.name} must implement ##{method_name}",
+            message: "#{constant.name} must implement #{ProtocolEvidence.describe(method_name, scope)}",
             location: constant.location,
-            evidence: ProtocolEvidence.for(constant, methods, unresolved),
+            evidence: ProtocolEvidence.for(constant, methods, unresolved, scope),
             confidence: unresolved.empty? ? :high : :medium
           )
         end
@@ -103,18 +104,19 @@ module ArchSpec
     # Backs ArchSpec::DSL::ComponentProxy#must_implement_one_of. Flags classes
     # that implement none of the named methods.
     class MustImplementOneOfRule
-      attr_reader :source, :method_names
+      attr_reader :source, :method_names, :scope
 
-      def initialize(source, method_names)
+      def initialize(source, method_names, scope: :instance)
         @source = source.to_sym
         names = Array(method_names).flatten.compact
         raise Error, 'must_implement_one_of requires at least one method' if names.empty?
 
         @method_names = names.map(&:to_sym)
+        @scope = ProtocolEvidence.validate_scope(scope)
       end
 
       def merge_key
-        [self.class, source]
+        [self.class, source, scope]
       end
 
       def merge!(other)
@@ -128,14 +130,15 @@ module ArchSpec
 
       def evaluate(graph)
         constants_for(graph).filter_map do |constant|
-          methods, unresolved = graph.effective_instance_methods(constant.name)
+          methods, unresolved = graph.effective_methods_in_scope(constant.name, scope)
           next if method_names.any? { |method_name| methods.include?(method_name) }
 
+          described = method_names.map { |name| ProtocolEvidence.describe(name, scope) }.join(', ')
           Diagnostic.new(
             rule: id,
-            message: "#{constant.name} must implement one of #{method_names.map { |name| "##{name}" }.join(', ')}",
+            message: "#{constant.name} must implement one of #{described}",
             location: constant.location,
-            evidence: ProtocolEvidence.for(constant, methods, unresolved),
+            evidence: ProtocolEvidence.for(constant, methods, unresolved, scope),
             confidence: unresolved.empty? ? :high : :medium
           )
         end
@@ -151,7 +154,19 @@ module ArchSpec
     # Builds the shared "methods: ..." evidence string for the protocol rules
     # and resolves the classes in a component. Internal helper.
     module ProtocolEvidence
+      VALID_SCOPES = %i[instance class].freeze
+
       module_function
+
+      def validate_scope(scope)
+        return scope if VALID_SCOPES.include?(scope)
+
+        raise Error, "protocol scope: must be :instance or :class, got #{scope.inspect}"
+      end
+
+      def describe(method_name, scope)
+        scope == :class ? ".#{method_name}" : "##{method_name}"
+      end
 
       def constants_for(graph, source)
         component = graph.components[source]
@@ -160,8 +175,10 @@ module ArchSpec
         graph.constants_for_component(source).select(&:class?).uniq(&:name)
       end
 
-      def for(constant, methods, unresolved)
-        evidence = "#{constant.name} methods: #{methods.empty? ? '(none)' : methods.to_a.sort.join(', ')}"
+      def for(constant, methods, unresolved, scope = :instance)
+        listed = methods.empty? ? '(none)' : methods.to_a.sort.join(', ')
+        label = scope == :class ? 'class methods' : 'methods'
+        evidence = "#{constant.name} #{label}: #{listed}"
         return evidence if unresolved.empty?
 
         "#{evidence}; unresolved ancestors: #{unresolved.to_a.sort.join(', ')}"

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -460,4 +460,59 @@ class AnalyzerTest < ArchSpecTest
       assert_equal [:models], graph.component_names_for_path("#{root}/app/models/user.rb").to_a
     end
   end
+
+  def test_except_removes_files_from_what_in_matched
+    with_project do |root|
+      write "#{root}/app/models/order.rb", "class Order; end\n"
+      write "#{root}/app/models/checkout_workflow.rb", "class CheckoutWorkflow; end\n"
+
+      definition = ArchSpec.define do
+        component :domain, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb'
+        component :workflows, in: 'app/models/**/*_workflow.rb'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+      domain = graph.components[:domain]
+      workflows = graph.components[:workflows]
+
+      assert_equal [File.join(root, 'app/models/order.rb')], domain.files.to_a
+      assert_equal Set['Order'], domain.constants
+      assert_equal Set['CheckoutWorkflow'], workflows.constants
+      assert_equal ['excluded by except pattern app/models/**/*_workflow.rb'],
+                   domain.exclusion_reasons[File.join(root, 'app/models/checkout_workflow.rb')].to_a
+    end
+  end
+
+  def test_except_leaves_namespace_and_constant_selectors_alone
+    with_project do |root|
+      write "#{root}/app/models/billing/invoice_workflow.rb", "module Billing; class InvoiceWorkflow; end; end\n"
+
+      definition = ArchSpec.define do
+        component :billing, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb', namespace: 'Billing'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+      billing = graph.components[:billing]
+
+      assert billing.includes_constant?('Billing::InvoiceWorkflow')
+      assert billing.files.include?(File.join(root, 'app/models/billing/invoice_workflow.rb'))
+    end
+  end
+
+  def test_except_patterns_merge_across_repeated_declarations
+    with_project do |root|
+      write "#{root}/app/models/order.rb", "class Order; end\n"
+      write "#{root}/app/models/checkout_workflow.rb", "class CheckoutWorkflow; end\n"
+      write "#{root}/app/models/legacy_report.rb", "class LegacyReport; end\n"
+
+      definition = ArchSpec.define do
+        component :domain, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb'
+        component :domain, except: 'app/models/legacy_*.rb'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+
+      assert_equal Set['Order'], graph.components[:domain].constants
+    end
+  end
 end

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -499,6 +499,32 @@ class AnalyzerTest < ArchSpecTest
     end
   end
 
+  def test_except_without_in_is_refused_at_declaration
+    error = assert_raises(ArchSpec::Error) do
+      ArchSpec.define do
+        component :domain, except: 'app/models/**/*_workflow.rb'
+      end
+    end
+
+    assert_match(/except: but no in:/, error.message)
+  end
+
+  def test_a_file_the_component_still_claims_is_not_listed_as_excluded
+    with_project do |root|
+      write "#{root}/app/models/billing/invoice_workflow.rb", "module Billing; class InvoiceWorkflow; end; end\n"
+
+      definition = ArchSpec.define do
+        component :billing, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb', namespace: 'Billing'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+      path = File.join(root, 'app/models/billing/invoice_workflow.rb')
+
+      assert_equal({}, graph.component_exclusion_reasons_for_path(path))
+      assert_includes graph.component_assignment_reasons_for_path(path)[:billing], 'defines Billing::InvoiceWorkflow'
+    end
+  end
+
   def test_except_patterns_merge_across_repeated_declarations
     with_project do |root|
       write "#{root}/app/models/order.rb", "class Order; end\n"

--- a/test/architectures_test.rb
+++ b/test/architectures_test.rb
@@ -448,4 +448,67 @@ class ArchitecturesTest < ArchSpecTest
       assert(diagnostics.any? { |diagnostic| diagnostic.message.match?(/models must not depend on controllers/) })
     end
   end
+
+  def test_layers_accept_except_to_carve_out_a_component
+    with_project do |root|
+      write "#{root}/app/controllers/orders_controller.rb", "class OrdersController; end\n"
+      write "#{root}/app/services/checkout.rb", "class Checkout; end\n"
+      write "#{root}/app/models/order.rb", "class Order; end\n"
+      write "#{root}/app/mailers/order_mailer.rb", "class OrderMailer; end\n"
+      write "#{root}/app/models/checkout_workflow.rb", <<~RUBY
+        class CheckoutWorkflow
+          def run
+            OrderMailer.new
+          end
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        architecture :layered, layers: {
+          interface: 'app/controllers/**/*.rb',
+          application: 'app/services/**/*.rb',
+          domain: { in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb' }
+        }
+        component :notifications, in: 'app/mailers/**/*.rb'
+        component :workflows, in: 'app/models/**/*_workflow.rb'
+        workflows.can_only_use :notifications
+      end
+
+      assert_empty diagnostics_for(definition, root)
+    end
+  end
+
+  def test_every_preset_accepts_except_in_the_hash_form
+    definition = ArchSpec.define do
+      architecture :rails, components: {
+        controllers: 'app/controllers/**/*.rb',
+        models: { in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb' }
+      }
+      architecture :hexagonal,
+                   application: 'app/application/**/*.rb',
+                   domain: { in: 'app/domain/**/*.rb', except: 'app/domain/support/**/*.rb' },
+                   ports: 'app/ports/**/*.rb',
+                   adapters: 'app/adapters/**/*.rb'
+      architecture :modular_monolith,
+                   components: { billing: { in: 'packs/billing/**/*.rb', except: 'packs/billing/spec/**/*.rb' } },
+                   allow: { billing: [] }
+    end
+
+    assert_equal ['app/models/**/*_workflow.rb'], definition.component_specs[:models].except_patterns
+    assert_equal ['app/domain/support/**/*.rb'], definition.component_specs[:domain].except_patterns
+    assert_equal ['packs/billing/spec/**/*.rb'], definition.component_specs[:billing].except_patterns
+  end
+
+  def test_presets_are_unchanged_without_except
+    layers = { interface: 'app/controllers/**/*.rb', domain: 'app/models/**/*.rb' }
+    plain = ArchSpec.define { architecture :layered, layers: layers }
+    hashed = ArchSpec.define do
+      architecture :layered, layers: layers.transform_values { |pattern| { in: pattern } }
+    end
+
+    assert_equal plain.rules.map { |rule| [rule.class, rule.id] }, hashed.rules.map { |rule| [rule.class, rule.id] }
+    assert_equal plain.component_specs.transform_values(&:file_patterns),
+                 hashed.component_specs.transform_values(&:file_patterns)
+    assert(plain.component_specs.values.all? { |spec| spec.except_patterns.empty? })
+  end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -331,6 +331,25 @@ class CLITest < ArchSpecTest
     end
   end
 
+  def test_explain_file_names_the_pattern_that_excluded_it
+    with_project do |root|
+      write "#{root}/Archspec.rb", <<~RUBY
+        component :domain, in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb"
+      RUBY
+
+      write "#{root}/app/models/checkout_workflow.rb", "class CheckoutWorkflow; end\n"
+
+      output = StringIO.new
+      status = Dir.chdir(root) do
+        ArchSpec::CLI.run(['explain', 'app/models/checkout_workflow.rb'], output: output, error: StringIO.new)
+      end
+
+      assert_equal 0, status
+      assert_match(/components: \(none\)/, output.string)
+      assert_match(%r{excluded from:\n    domain: excluded by except pattern app/models/\*\*/\*_workflow\.rb}, output.string)
+    end
+  end
+
   def test_explain_file_includes_suppressions
     with_project do |root|
       write "#{root}/Archspec.rb", <<~RUBY

--- a/test/rules_test.rb
+++ b/test/rules_test.rb
@@ -808,4 +808,114 @@ class RulesTest < ArchSpecTest
 
     assert_match(/no_cycles references unknown component: controlers/, error.message)
   end
+
+  def test_must_implement_with_class_scope_counts_extended_modules_and_superclasses
+    with_project do |root|
+      write "#{root}/app/jobs/enqueueable.rb", <<~RUBY
+        module Enqueueable
+          def perform_later
+          end
+        end
+      RUBY
+
+      write "#{root}/app/jobs/application_job.rb", <<~RUBY
+        class ApplicationJob
+          def self.perform_later
+          end
+        end
+      RUBY
+
+      write "#{root}/app/jobs/import_job.rb", <<~RUBY
+        class ImportJob
+          extend Enqueueable
+        end
+      RUBY
+
+      write "#{root}/app/jobs/export_job.rb", <<~RUBY
+        class ExportJob < ApplicationJob
+        end
+      RUBY
+
+      write "#{root}/app/jobs/broken_job.rb", <<~RUBY
+        class BrokenJob
+          include Enqueueable
+
+          def perform_later
+          end
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement :perform_later, scope: :class
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_equal 'BrokenJob must implement .perform_later', diagnostics.first.message
+      assert_match(/BrokenJob class methods: \(none\)/, diagnostics.first.evidence)
+      assert_equal :high, diagnostics.first.confidence
+    end
+  end
+
+  def test_class_scope_protocols_downgrade_confidence_for_unresolved_extended_modules
+    with_project do |root|
+      write "#{root}/app/jobs/import_job.rb", <<~RUBY
+        class ImportJob
+          extend SomeGem::Enqueueable
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement_one_of :perform_later, :enqueue, scope: :class
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_equal :medium, diagnostics.first.confidence
+      assert_match(/unresolved ancestors: SomeGem::Enqueueable/, diagnostics.first.evidence)
+    end
+  end
+
+  def test_instance_protocols_ignore_extended_modules
+    with_project do |root|
+      write "#{root}/app/jobs/enqueueable.rb", <<~RUBY
+        module Enqueueable
+          def perform
+          end
+        end
+      RUBY
+
+      write "#{root}/app/jobs/import_job.rb", <<~RUBY
+        class ImportJob
+          extend Enqueueable
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement :perform
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_equal 'ImportJob must implement #perform', diagnostics.first.message
+      assert_match(/ImportJob methods: \(none\)/, diagnostics.first.evidence)
+    end
+  end
+
+  def test_protocol_scope_must_be_instance_or_class
+    error = assert_raises(ArchSpec::Error) do
+      ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement :perform, scope: :singleton
+      end
+    end
+
+    assert_match(/protocol scope: must be :instance or :class, got :singleton/, error.message)
+  end
 end


### PR DESCRIPTION
A component can now carve files out of its globs with `except:`, and a protocol rule can ask for class methods with `scope: :class`. This is the `except:` you proposed in #7 instead of `can_also_use`: a component keeps exactly one allowlist and restates it, so `can_only_use` stays without holes. The `layers:` hash and every preset that takes a components hash accept the same `in:`/`except:` form, and `explain` names the pattern that excluded a file.

`must_implement` and `must_implement_one_of` default to the instance side as before. With `scope: :class` they walk the class side: the constant's own class methods, modules brought in with `extend`, and the superclass chain, with the same medium-confidence downgrade when an ancestor is unresolved. Folding `extend` into the instance walk was rejected as wrong Ruby.

This PR stands alone. Presets without `except:` produce byte-identical diagnostics, existing todo fingerprints do not move, and ten of the eleven new tests fail on `master` (the eleventh, instance protocols ignoring `extend`, passes there by construction). If #7 lands `except:` first, this reduces to the class-side half.