### PR TITLE
Record every torture diagnostic with a verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ It also runs against pinned checkouts of large real-world Rails apps to catch cr
 bundle exec rake torture
 ```
 
+Each app's `test/torture/<app>/expected.yml` records every diagnostic the pinned checkout produces, keyed by the same fingerprint the todo file uses, with a verdict: `true_positive`, `false_positive`, or `unjudged`. A run fails when the per-rule counts move, when a diagnostic appears that the record does not carry, or when a true positive disappears. `--update` records new diagnostics as `unjudged` and keeps every verdict already written; a verdict is written by a person editing the file, never by the tool, and a true positive only leaves the record by hand.
+
 ## License
 
 Released under the MIT License.

--- a/docs/_reference/configuration.md
+++ b/docs/_reference/configuration.md
@@ -29,7 +29,7 @@ component :domain,      in: "app/models/**/*.rb", except: "app/models/**/*_workf
 component :workflows,   in: "app/models/**/*_workflow.rb"
 ```
 
-`except:` removes files from what `in:` matched. A few files that need wider grants than their layer become their own component with their own allowlist, instead of a hole in the layer's. The same keyword works inside the hash form every architecture accepts, so a layer in `layers:` can read `{ in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb" }`.
+`except:` removes files from what `in:` matched, and only those: a file the component also claims through `namespace:` or `constants:` stays a member. A component with `except:` and no `in:` is an error. A few files that need wider grants than their layer become their own component with their own allowlist, instead of a hole in the layer's. The same keyword works inside the hash form every architecture accepts, so a layer in `layers:` can read `{ in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb" }`.
 
 Declare one component per subdirectory with `each_directory`, which is handy for engines and packs:
 

--- a/docs/_reference/configuration.md
+++ b/docs/_reference/configuration.md
@@ -25,7 +25,11 @@ Todo ids are computed from the rule, path, message, and evidence, not the line n
 component :controllers, in: "app/controllers/**/*.rb"
 component :models,      in: "app/models/**/*.rb"
 component :billing,     namespace: "Billing"
+component :domain,      in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb"
+component :workflows,   in: "app/models/**/*_workflow.rb"
 ```
+
+`except:` removes files from what `in:` matched. A few files that need wider grants than their layer become their own component with their own allowlist, instead of a hole in the layer's. The same keyword works inside the hash form every architecture accepts, so a layer in `layers:` can read `{ in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb" }`.
 
 Declare one component per subdirectory with `each_directory`, which is handy for engines and packs:
 

--- a/docs/_rules/protocols.md
+++ b/docs/_rules/protocols.md
@@ -6,7 +6,7 @@ description: Use ArchSpec protocol rules to require classes in a component to im
 
 # Protocols
 
-Protocol rules check that classes in a component define expected instance methods.
+Protocol rules check that classes in a component define expected methods. Instance methods by default; pass `scope: :class` for a class-side protocol.
 
 ## Require One Method
 
@@ -23,5 +23,13 @@ queries.must_implement_one_of :call, :resolve
 ```
 
 Rule id: `protocol.must_implement_one_of`
+
+## Class-Side Protocols
+
+```ruby
+jobs.must_implement :perform_later, scope: :class
+```
+
+With `scope: :class` the rule counts the class's own class methods, the instance methods of every module it `extend`s, and the class methods of its superclass chain. An ancestor ArchSpec cannot resolve lowers the diagnostic to medium confidence, as it does for instance protocols.
 
 These checks are intentionally simple. They verify the visible method definitions in source. They do not prove behavior.

--- a/lib/archspec/architectures.rb
+++ b/lib/archspec/architectures.rb
@@ -317,6 +317,7 @@ module ArchSpec
         dsl.component(
           name,
           in: selector[:in] || selector[:files],
+          except: selector[:except],
           namespace: selector[:namespace],
           constants: selector[:constants]
         )

--- a/lib/archspec/component_spec.rb
+++ b/lib/archspec/component_spec.rb
@@ -2,20 +2,23 @@
 
 module ArchSpec
   # How a component selects its members: by file glob, by namespace, or by
-  # explicit constant name. Created by ArchSpec::DSL::Context#component. The
-  # analyzer uses it to assign files and constants to the component.
+  # explicit constant name, minus any file an +except+ glob names. Created by
+  # ArchSpec::DSL::Context#component. The analyzer uses it to assign files and
+  # constants to the component.
   class ComponentSpec
-    attr_reader :name, :file_patterns, :namespaces, :constants
+    attr_reader :name, :file_patterns, :except_patterns, :namespaces, :constants
 
-    def initialize(name, files: [], namespace: nil, constants: nil)
+    def initialize(name, files: [], except: [], namespace: nil, constants: nil)
       @name = name.to_sym
       @file_patterns = Array(files).compact.map(&:to_s)
+      @except_patterns = Array(except).compact.map(&:to_s)
       @namespaces = Array(namespace).compact.map { |value| normalize_constant(value) }
       @constants = Array(constants).compact.map { |value| normalize_constant(value) }
     end
 
     def merge!(other)
       @file_patterns |= other.file_patterns
+      @except_patterns |= other.except_patterns
       @namespaces |= other.namespaces
       @constants |= other.constants
       self

--- a/lib/archspec/definition.rb
+++ b/lib/archspec/definition.rb
@@ -49,6 +49,10 @@ module ArchSpec
       else
         component_specs[spec.name] = spec
       end
+      merged = component_specs.fetch(spec.name)
+      return if merged.except_patterns.empty? || merged.file_patterns.any?
+
+      raise Error, "component :#{spec.name} has except: but no in: to exclude from"
     end
 
     def component?(name)

--- a/lib/archspec/dsl.rb
+++ b/lib/archspec/dsl.rb
@@ -92,14 +92,26 @@ module ArchSpec
       # or explicit constant.
       #
       #   component :services, in: "app/services/**/*.rb"
+      #   component :domain, in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb"
       #   component :billing, namespace: "Billing"
       #   component :legacy, constants: %w[OldReport OldExport]
       #
+      # +except:+ removes files from what +in:+ matched, so a handful of files
+      # can form their own component with their own rules instead of a hole in
+      # this one's allowlist. It never widens anything: the carved-out component
+      # states its own dependencies.
+      #
       # Returns an ArchSpec::DSL::ComponentProxy for attaching rules. The
       # component is also available by name later in the file.
-      def component(name, in: nil, namespace: nil, constants: nil)
+      def component(name, in: nil, except: nil, namespace: nil, constants: nil)
         add_component(
-          ComponentSpec.new(name, files: binding.local_variable_get(:in), namespace: namespace, constants: constants)
+          ComponentSpec.new(
+            name,
+            files: binding.local_variable_get(:in),
+            except: except,
+            namespace: namespace,
+            constants: constants
+          )
         )
         ComponentProxy.new(self, name)
       end
@@ -295,29 +307,33 @@ module ArchSpec
       end
 
       # Requires every class in the component to implement all the named
-      # instance methods. Methods inherited from resolvable superclasses or
-      # mixins count.
+      # methods. Methods inherited from resolvable superclasses or mixins
+      # count. Pass <tt>scope: :class</tt> for a class-side protocol, which
+      # counts class methods, methods from +extend+ed modules, and the
+      # superclass chain's class methods.
       #
       #   commands.must_implement :perform
+      #   jobs.must_implement :perform_later, scope: :class
       #
       # Rule id: +protocol.must_implement+.
-      def must_implement(*methods)
+      def must_implement(*methods, scope: :instance)
         raise Error, 'must_implement requires at least one method' if methods.flatten.compact.empty?
 
-        methods.each do |method_name|
-          add_rule(Rules::MustImplementRule.new(name, method_name))
+        methods.flatten.each do |method_name|
+          add_rule(Rules::MustImplementRule.new(name, method_name, scope: scope))
         end
         self
       end
 
       # Requires every class in the component to implement at least one of the
-      # named instance methods. Useful when a protocol allows either name.
+      # named methods. Useful when a protocol allows either name. Takes the
+      # same +scope:+ as +must_implement+.
       #
       #   commands.must_implement_one_of :perform, :call
       #
       # Rule id: +protocol.must_implement_one_of+.
-      def must_implement_one_of(*methods)
-        add_rule(Rules::MustImplementOneOfRule.new(name, methods))
+      def must_implement_one_of(*methods, scope: :instance)
+        add_rule(Rules::MustImplementOneOfRule.new(name, methods, scope: scope))
         self
       end
 

--- a/lib/archspec/dsl.rb
+++ b/lib/archspec/dsl.rb
@@ -319,7 +319,7 @@ module ArchSpec
       def must_implement(*methods, scope: :instance)
         raise Error, 'must_implement requires at least one method' if methods.flatten.compact.empty?
 
-        methods.flatten.each do |method_name|
+        methods.each do |method_name|
           add_rule(Rules::MustImplementRule.new(name, method_name, scope: scope))
         end
         self

--- a/lib/archspec/formatters/explanation.rb
+++ b/lib/archspec/formatters/explanation.rb
@@ -27,6 +27,7 @@ module ArchSpec
         output.puts "  #{style.note('defined constants:')} #{graph.constants_for_path(path).map(&:name).join(', ')}"
         print_parse_errors(output, style, file)
         print_component_reasons(output, style, graph.component_assignment_reasons_for_path(path))
+        print_component_exclusions(output, style, graph.component_exclusion_reasons_for_path(path))
         print_suppressions(output, style, file)
         print_facts(output, style, graph.edges.select { |edge| edge.from_path == path })
       end
@@ -60,6 +61,15 @@ module ArchSpec
         output.puts "  #{style.note('components:')}"
         assignments.sort_by { |name, _reasons| name.to_s }.each do |name, reasons|
           output.puts "    #{name}: #{reasons.empty? ? '(no recorded reason)' : reasons.join('; ')}"
+        end
+      end
+
+      def print_component_exclusions(output, style, exclusions)
+        return if exclusions.empty?
+
+        output.puts "  #{style.note('excluded from:')}"
+        exclusions.sort_by { |name, _reasons| name.to_s }.each do |name, reasons|
+          output.puts "    #{name}: #{reasons.join('; ')}"
         end
       end
 

--- a/lib/archspec/model.rb
+++ b/lib/archspec/model.rb
@@ -127,6 +127,16 @@ module ArchSpec
       file_reasons[path].add(reason) if reason
     end
 
+    def remove_file(path, reason: nil)
+      files.delete(path)
+      file_reasons.delete(path)
+      exclusion_reasons[path].add(reason) if reason
+    end
+
+    def exclusion_reasons
+      @exclusion_reasons ||= Hash.new { |hash, key| hash[key] = Set.new }
+    end
+
     def add_constant(name, path:, reason: nil)
       constants.add(name)
       @constant_occurrences.add([name, path])
@@ -223,6 +233,14 @@ module ArchSpec
           end
         end
 
+        spec.except_patterns.each do |pattern|
+          each_matching_file(pattern) do |path|
+            next unless files_matched_by_pattern.delete?(path)
+
+            component.remove_file(path, reason: "excluded by except pattern #{pattern}")
+          end
+        end
+
         constants.each do |constant|
           matched_file = files_matched_by_pattern.include?(constant.path)
           matched_constant = spec.matches_constant?(constant.name)
@@ -303,43 +321,23 @@ module ArchSpec
     # and include/prepend mixins. Returns [methods, unresolved ancestor names];
     # a non-empty second element means the answer is incomplete.
     def effective_instance_methods(name, visited = Set.new)
-      normalized = normalize_constant(name)
-      return [Set.new, Set.new] if visited.include?(normalized)
-
-      visited.add(normalized)
-      return [Set.new, Set.new] if RESOLVED_ROOTS.include?(normalized)
-
-      nodes = constants_named(normalized)
-      return [Set.new, Set[normalized]] if nodes.empty?
-
-      methods = Set.new
-      unresolved = Set.new
-
-      nodes.each do |node|
-        methods.merge(node.instance_methods)
-
+      effective_methods(name, visited) do |node|
         mixins = node.mixins[:include].to_a + node.mixins[:prepend].to_a
-
-        mixins.each do |ancestor|
-          resolved_name = resolve_constant_reference(
-            ancestor,
-            node.name,
-            lexical_nesting: [node.name] + node.nesting
-          )
-          ancestor_methods, ancestor_unresolved = effective_instance_methods(resolved_name, visited)
-          methods.merge(ancestor_methods)
-          unresolved.merge(ancestor_unresolved)
-        end
-
-        if node.superclass
-          resolved_name = resolve_constant_reference(node.superclass, node.name, lexical_nesting: node.nesting)
-          ancestor_methods, ancestor_unresolved = effective_instance_methods(resolved_name, visited)
-          methods.merge(ancestor_methods)
-          unresolved.merge(ancestor_unresolved)
-        end
+        [node.instance_methods, mixins.map { |ancestor| [ancestor, :instance] }, :instance]
       end
+    end
 
-      [methods, unresolved]
+    # A class's methods on the class side: its own, those of every module it
+    # +extend+s (their instance methods land on the singleton), and the class
+    # methods of its superclass chain.
+    def effective_class_methods(name, visited = Set.new)
+      effective_methods(name, visited) do |node|
+        [node.class_methods, node.mixins[:extend].to_a.map { |ancestor| [ancestor, :instance] }, :class]
+      end
+    end
+
+    def effective_methods_in_scope(name, scope)
+      scope == :class ? effective_class_methods(name) : effective_instance_methods(name)
     end
 
     def component_assignment_reasons_for_path(path)
@@ -347,6 +345,14 @@ module ArchSpec
         next unless component.files.include?(path)
 
         reasons[component.name] = component.file_reasons[path].to_a.sort
+      end
+    end
+
+    def component_exclusion_reasons_for_path(path)
+      components.values.each_with_object({}) do |component, reasons|
+        next unless component.exclusion_reasons.key?(path)
+
+        reasons[component.name] = component.exclusion_reasons[path].to_a.sort
       end
     end
 
@@ -372,6 +378,57 @@ module ArchSpec
     end
 
     private
+
+    # Walks a constant's ancestry collecting methods. The block maps a node to
+    # its own methods in the requested scope, the mixins to follow with the
+    # scope to read them in, and the scope to read the superclass chain in.
+    # Superclass resolution and the cycle guard are shared by both walks.
+    def effective_methods(name, visited, &scope_of)
+      normalized = normalize_constant(name)
+      return [Set.new, Set.new] if visited.include?(normalized)
+
+      visited.add(normalized)
+      return [Set.new, Set.new] if RESOLVED_ROOTS.include?(normalized)
+
+      nodes = constants_named(normalized)
+      return [Set.new, Set[normalized]] if nodes.empty?
+
+      methods = Set.new
+      unresolved = Set.new
+
+      nodes.each do |node|
+        own_methods, mixins, superclass_scope = yield(node)
+        methods.merge(own_methods)
+
+        mixins.each do |ancestor, scope|
+          resolved_name = resolve_constant_reference(
+            ancestor,
+            node.name,
+            lexical_nesting: [node.name] + node.nesting
+          )
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, scope, visited, &scope_of)
+          methods.merge(ancestor_methods)
+          unresolved.merge(ancestor_unresolved)
+        end
+
+        if node.superclass
+          resolved_name = resolve_constant_reference(node.superclass, node.name, lexical_nesting: node.nesting)
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, superclass_scope, visited, &scope_of)
+          methods.merge(ancestor_methods)
+          unresolved.merge(ancestor_unresolved)
+        end
+      end
+
+      [methods, unresolved]
+    end
+
+    def walk_ancestor(name, scope, visited, &scope_of)
+      if scope == :instance
+        effective_instance_methods(name, visited)
+      else
+        effective_methods(name, visited, &scope_of)
+      end
+    end
 
     def each_matching_file(pattern)
       glob = File.absolute_path(pattern, root)

--- a/lib/archspec/model.rb
+++ b/lib/archspec/model.rb
@@ -351,6 +351,7 @@ module ArchSpec
     def component_exclusion_reasons_for_path(path)
       components.values.each_with_object({}) do |component, reasons|
         next unless component.exclusion_reasons.key?(path)
+        next if component.files.include?(path)
 
         reasons[component.name] = component.exclusion_reasons[path].to_a.sort
       end
@@ -383,7 +384,7 @@ module ArchSpec
     # its own methods in the requested scope, the mixins to follow with the
     # scope to read them in, and the scope to read the superclass chain in.
     # Superclass resolution and the cycle guard are shared by both walks.
-    def effective_methods(name, visited, &scope_of)
+    def effective_methods(name, visited, &)
       normalized = normalize_constant(name)
       return [Set.new, Set.new] if visited.include?(normalized)
 
@@ -406,14 +407,14 @@ module ArchSpec
             node.name,
             lexical_nesting: [node.name] + node.nesting
           )
-          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, scope, visited, &scope_of)
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, scope, visited, &)
           methods.merge(ancestor_methods)
           unresolved.merge(ancestor_unresolved)
         end
 
         if node.superclass
           resolved_name = resolve_constant_reference(node.superclass, node.name, lexical_nesting: node.nesting)
-          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, superclass_scope, visited, &scope_of)
+          ancestor_methods, ancestor_unresolved = walk_ancestor(resolved_name, superclass_scope, visited, &)
           methods.merge(ancestor_methods)
           unresolved.merge(ancestor_unresolved)
         end
@@ -422,11 +423,11 @@ module ArchSpec
       [methods, unresolved]
     end
 
-    def walk_ancestor(name, scope, visited, &scope_of)
+    def walk_ancestor(name, scope, visited, &)
       if scope == :instance
         effective_instance_methods(name, visited)
       else
-        effective_methods(name, visited, &scope_of)
+        effective_methods(name, visited, &)
       end
     end
 

--- a/lib/archspec/rules/protocol_rules.rb
+++ b/lib/archspec/rules/protocol_rules.rb
@@ -63,15 +63,16 @@ module ArchSpec
     # component that do not implement the method, counting inherited and
     # mixed-in methods.
     class MustImplementRule
-      attr_reader :source, :method_name
+      attr_reader :source, :method_name, :scope
 
-      def initialize(source, method_name)
+      def initialize(source, method_name, scope: :instance)
         @source = source.to_sym
         @method_name = method_name.to_sym
+        @scope = ProtocolEvidence.validate_scope(scope)
       end
 
       def merge_key
-        [self.class, source, method_name]
+        [self.class, source, method_name, scope]
       end
 
       def id
@@ -80,14 +81,14 @@ module ArchSpec
 
       def evaluate(graph)
         constants_for(graph).filter_map do |constant|
-          methods, unresolved = graph.effective_instance_methods(constant.name)
+          methods, unresolved = graph.effective_methods_in_scope(constant.name, scope)
           next if methods.include?(method_name)
 
           Diagnostic.new(
             rule: id,
-            message: "#{constant.name} must implement ##{method_name}",
+            message: "#{constant.name} must implement #{ProtocolEvidence.describe(method_name, scope)}",
             location: constant.location,
-            evidence: ProtocolEvidence.for(constant, methods, unresolved),
+            evidence: ProtocolEvidence.for(constant, methods, unresolved, scope),
             confidence: unresolved.empty? ? :high : :medium
           )
         end
@@ -103,18 +104,19 @@ module ArchSpec
     # Backs ArchSpec::DSL::ComponentProxy#must_implement_one_of. Flags classes
     # that implement none of the named methods.
     class MustImplementOneOfRule
-      attr_reader :source, :method_names
+      attr_reader :source, :method_names, :scope
 
-      def initialize(source, method_names)
+      def initialize(source, method_names, scope: :instance)
         @source = source.to_sym
         names = Array(method_names).flatten.compact
         raise Error, 'must_implement_one_of requires at least one method' if names.empty?
 
         @method_names = names.map(&:to_sym)
+        @scope = ProtocolEvidence.validate_scope(scope)
       end
 
       def merge_key
-        [self.class, source]
+        [self.class, source, scope]
       end
 
       def merge!(other)
@@ -128,14 +130,15 @@ module ArchSpec
 
       def evaluate(graph)
         constants_for(graph).filter_map do |constant|
-          methods, unresolved = graph.effective_instance_methods(constant.name)
+          methods, unresolved = graph.effective_methods_in_scope(constant.name, scope)
           next if method_names.any? { |method_name| methods.include?(method_name) }
 
+          described = method_names.map { |name| ProtocolEvidence.describe(name, scope) }.join(', ')
           Diagnostic.new(
             rule: id,
-            message: "#{constant.name} must implement one of #{method_names.map { |name| "##{name}" }.join(', ')}",
+            message: "#{constant.name} must implement one of #{described}",
             location: constant.location,
-            evidence: ProtocolEvidence.for(constant, methods, unresolved),
+            evidence: ProtocolEvidence.for(constant, methods, unresolved, scope),
             confidence: unresolved.empty? ? :high : :medium
           )
         end
@@ -151,7 +154,19 @@ module ArchSpec
     # Builds the shared "methods: ..." evidence string for the protocol rules
     # and resolves the classes in a component. Internal helper.
     module ProtocolEvidence
+      VALID_SCOPES = %i[instance class].freeze
+
       module_function
+
+      def validate_scope(scope)
+        return scope if VALID_SCOPES.include?(scope)
+
+        raise Error, "protocol scope: must be :instance or :class, got #{scope.inspect}"
+      end
+
+      def describe(method_name, scope)
+        scope == :class ? ".#{method_name}" : "##{method_name}"
+      end
 
       def constants_for(graph, source)
         component = graph.components[source]
@@ -160,8 +175,10 @@ module ArchSpec
         graph.constants_for_component(source).select(&:class?).uniq(&:name)
       end
 
-      def for(constant, methods, unresolved)
-        evidence = "#{constant.name} methods: #{methods.empty? ? '(none)' : methods.to_a.sort.join(', ')}"
+      def for(constant, methods, unresolved, scope = :instance)
+        listed = methods.empty? ? '(none)' : methods.to_a.sort.join(', ')
+        label = scope == :class ? 'class methods' : 'methods'
+        evidence = "#{constant.name} #{label}: #{listed}"
         return evidence if unresolved.empty?
 
         "#{evidence}; unresolved ancestors: #{unresolved.to_a.sort.join(', ')}"

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -460,4 +460,59 @@ class AnalyzerTest < ArchSpecTest
       assert_equal [:models], graph.component_names_for_path("#{root}/app/models/user.rb").to_a
     end
   end
+
+  def test_except_removes_files_from_what_in_matched
+    with_project do |root|
+      write "#{root}/app/models/order.rb", "class Order; end\n"
+      write "#{root}/app/models/checkout_workflow.rb", "class CheckoutWorkflow; end\n"
+
+      definition = ArchSpec.define do
+        component :domain, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb'
+        component :workflows, in: 'app/models/**/*_workflow.rb'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+      domain = graph.components[:domain]
+      workflows = graph.components[:workflows]
+
+      assert_equal [File.join(root, 'app/models/order.rb')], domain.files.to_a
+      assert_equal Set['Order'], domain.constants
+      assert_equal Set['CheckoutWorkflow'], workflows.constants
+      assert_equal ['excluded by except pattern app/models/**/*_workflow.rb'],
+                   domain.exclusion_reasons[File.join(root, 'app/models/checkout_workflow.rb')].to_a
+    end
+  end
+
+  def test_except_leaves_namespace_and_constant_selectors_alone
+    with_project do |root|
+      write "#{root}/app/models/billing/invoice_workflow.rb", "module Billing; class InvoiceWorkflow; end; end\n"
+
+      definition = ArchSpec.define do
+        component :billing, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb', namespace: 'Billing'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+      billing = graph.components[:billing]
+
+      assert billing.includes_constant?('Billing::InvoiceWorkflow')
+      assert billing.files.include?(File.join(root, 'app/models/billing/invoice_workflow.rb'))
+    end
+  end
+
+  def test_except_patterns_merge_across_repeated_declarations
+    with_project do |root|
+      write "#{root}/app/models/order.rb", "class Order; end\n"
+      write "#{root}/app/models/checkout_workflow.rb", "class CheckoutWorkflow; end\n"
+      write "#{root}/app/models/legacy_report.rb", "class LegacyReport; end\n"
+
+      definition = ArchSpec.define do
+        component :domain, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb'
+        component :domain, except: 'app/models/legacy_*.rb'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+
+      assert_equal Set['Order'], graph.components[:domain].constants
+    end
+  end
 end

--- a/test/analyzer_test.rb
+++ b/test/analyzer_test.rb
@@ -499,6 +499,32 @@ class AnalyzerTest < ArchSpecTest
     end
   end
 
+  def test_except_without_in_is_refused_at_declaration
+    error = assert_raises(ArchSpec::Error) do
+      ArchSpec.define do
+        component :domain, except: 'app/models/**/*_workflow.rb'
+      end
+    end
+
+    assert_match(/except: but no in:/, error.message)
+  end
+
+  def test_a_file_the_component_still_claims_is_not_listed_as_excluded
+    with_project do |root|
+      write "#{root}/app/models/billing/invoice_workflow.rb", "module Billing; class InvoiceWorkflow; end; end\n"
+
+      definition = ArchSpec.define do
+        component :billing, in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb', namespace: 'Billing'
+      end
+
+      graph = ArchSpec::Analyzer.analyze(definition, root: root)
+      path = File.join(root, 'app/models/billing/invoice_workflow.rb')
+
+      assert_equal({}, graph.component_exclusion_reasons_for_path(path))
+      assert_includes graph.component_assignment_reasons_for_path(path)[:billing], 'defines Billing::InvoiceWorkflow'
+    end
+  end
+
   def test_except_patterns_merge_across_repeated_declarations
     with_project do |root|
       write "#{root}/app/models/order.rb", "class Order; end\n"

--- a/test/architectures_test.rb
+++ b/test/architectures_test.rb
@@ -448,4 +448,67 @@ class ArchitecturesTest < ArchSpecTest
       assert(diagnostics.any? { |diagnostic| diagnostic.message.match?(/models must not depend on controllers/) })
     end
   end
+
+  def test_layers_accept_except_to_carve_out_a_component
+    with_project do |root|
+      write "#{root}/app/controllers/orders_controller.rb", "class OrdersController; end\n"
+      write "#{root}/app/services/checkout.rb", "class Checkout; end\n"
+      write "#{root}/app/models/order.rb", "class Order; end\n"
+      write "#{root}/app/mailers/order_mailer.rb", "class OrderMailer; end\n"
+      write "#{root}/app/models/checkout_workflow.rb", <<~RUBY
+        class CheckoutWorkflow
+          def run
+            OrderMailer.new
+          end
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        architecture :layered, layers: {
+          interface: 'app/controllers/**/*.rb',
+          application: 'app/services/**/*.rb',
+          domain: { in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb' }
+        }
+        component :notifications, in: 'app/mailers/**/*.rb'
+        component :workflows, in: 'app/models/**/*_workflow.rb'
+        workflows.can_only_use :notifications
+      end
+
+      assert_empty diagnostics_for(definition, root)
+    end
+  end
+
+  def test_every_preset_accepts_except_in_the_hash_form
+    definition = ArchSpec.define do
+      architecture :rails, components: {
+        controllers: 'app/controllers/**/*.rb',
+        models: { in: 'app/models/**/*.rb', except: 'app/models/**/*_workflow.rb' }
+      }
+      architecture :hexagonal,
+                   application: 'app/application/**/*.rb',
+                   domain: { in: 'app/domain/**/*.rb', except: 'app/domain/support/**/*.rb' },
+                   ports: 'app/ports/**/*.rb',
+                   adapters: 'app/adapters/**/*.rb'
+      architecture :modular_monolith,
+                   components: { billing: { in: 'packs/billing/**/*.rb', except: 'packs/billing/spec/**/*.rb' } },
+                   allow: { billing: [] }
+    end
+
+    assert_equal ['app/models/**/*_workflow.rb'], definition.component_specs[:models].except_patterns
+    assert_equal ['app/domain/support/**/*.rb'], definition.component_specs[:domain].except_patterns
+    assert_equal ['packs/billing/spec/**/*.rb'], definition.component_specs[:billing].except_patterns
+  end
+
+  def test_presets_are_unchanged_without_except
+    layers = { interface: 'app/controllers/**/*.rb', domain: 'app/models/**/*.rb' }
+    plain = ArchSpec.define { architecture :layered, layers: layers }
+    hashed = ArchSpec.define do
+      architecture :layered, layers: layers.transform_values { |pattern| { in: pattern } }
+    end
+
+    assert_equal plain.rules.map { |rule| [rule.class, rule.id] }, hashed.rules.map { |rule| [rule.class, rule.id] }
+    assert_equal plain.component_specs.transform_values(&:file_patterns),
+                 hashed.component_specs.transform_values(&:file_patterns)
+    assert(plain.component_specs.values.all? { |spec| spec.except_patterns.empty? })
+  end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -331,6 +331,25 @@ class CLITest < ArchSpecTest
     end
   end
 
+  def test_explain_file_names_the_pattern_that_excluded_it
+    with_project do |root|
+      write "#{root}/Archspec.rb", <<~RUBY
+        component :domain, in: "app/models/**/*.rb", except: "app/models/**/*_workflow.rb"
+      RUBY
+
+      write "#{root}/app/models/checkout_workflow.rb", "class CheckoutWorkflow; end\n"
+
+      output = StringIO.new
+      status = Dir.chdir(root) do
+        ArchSpec::CLI.run(['explain', 'app/models/checkout_workflow.rb'], output: output, error: StringIO.new)
+      end
+
+      assert_equal 0, status
+      assert_match(/components: \(none\)/, output.string)
+      assert_match(%r{excluded from:\n    domain: excluded by except pattern app/models/\*\*/\*_workflow\.rb}, output.string)
+    end
+  end
+
   def test_explain_file_includes_suppressions
     with_project do |root|
       write "#{root}/Archspec.rb", <<~RUBY

--- a/test/rules_test.rb
+++ b/test/rules_test.rb
@@ -808,4 +808,114 @@ class RulesTest < ArchSpecTest
 
     assert_match(/no_cycles references unknown component: controlers/, error.message)
   end
+
+  def test_must_implement_with_class_scope_counts_extended_modules_and_superclasses
+    with_project do |root|
+      write "#{root}/app/jobs/enqueueable.rb", <<~RUBY
+        module Enqueueable
+          def perform_later
+          end
+        end
+      RUBY
+
+      write "#{root}/app/jobs/application_job.rb", <<~RUBY
+        class ApplicationJob
+          def self.perform_later
+          end
+        end
+      RUBY
+
+      write "#{root}/app/jobs/import_job.rb", <<~RUBY
+        class ImportJob
+          extend Enqueueable
+        end
+      RUBY
+
+      write "#{root}/app/jobs/export_job.rb", <<~RUBY
+        class ExportJob < ApplicationJob
+        end
+      RUBY
+
+      write "#{root}/app/jobs/broken_job.rb", <<~RUBY
+        class BrokenJob
+          include Enqueueable
+
+          def perform_later
+          end
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement :perform_later, scope: :class
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_equal 'BrokenJob must implement .perform_later', diagnostics.first.message
+      assert_match(/BrokenJob class methods: \(none\)/, diagnostics.first.evidence)
+      assert_equal :high, diagnostics.first.confidence
+    end
+  end
+
+  def test_class_scope_protocols_downgrade_confidence_for_unresolved_extended_modules
+    with_project do |root|
+      write "#{root}/app/jobs/import_job.rb", <<~RUBY
+        class ImportJob
+          extend SomeGem::Enqueueable
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement_one_of :perform_later, :enqueue, scope: :class
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_equal :medium, diagnostics.first.confidence
+      assert_match(/unresolved ancestors: SomeGem::Enqueueable/, diagnostics.first.evidence)
+    end
+  end
+
+  def test_instance_protocols_ignore_extended_modules
+    with_project do |root|
+      write "#{root}/app/jobs/enqueueable.rb", <<~RUBY
+        module Enqueueable
+          def perform
+          end
+        end
+      RUBY
+
+      write "#{root}/app/jobs/import_job.rb", <<~RUBY
+        class ImportJob
+          extend Enqueueable
+        end
+      RUBY
+
+      definition = ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement :perform
+      end
+
+      diagnostics = diagnostics_for(definition, root)
+
+      assert_equal 1, diagnostics.size
+      assert_equal 'ImportJob must implement #perform', diagnostics.first.message
+      assert_match(/ImportJob methods: \(none\)/, diagnostics.first.evidence)
+    end
+  end
+
+  def test_protocol_scope_must_be_instance_or_class
+    error = assert_raises(ArchSpec::Error) do
+      ArchSpec.define do
+        component :jobs, in: 'app/jobs/**/*.rb'
+        jobs.must_implement :perform, scope: :singleton
+      end
+    end
+
+    assert_match(/protocol scope: must be :instance or :class, got :singleton/, error.message)
+  end
 end

--- a/test/torture/discourse/expected.yml
+++ b/test/torture/discourse/expected.yml
@@ -2,3 +2,58 @@
 sha: 4cac48263809d806cee8660c6b1adc6e5d0c9445
 rules:
   dependencies.forbid: 10
+diagnostics:
+  0ab6ff052afba42496dac115:
+    rule: dependencies.forbid
+    path: app/services/user_authenticator.rb
+    message: services must not depend on controllers
+    evidence: UserAuthenticator references Users::OmniauthCallbacksController
+    verdict: unjudged
+  1c39cf10a18a1664f58bd15f:
+    rule: dependencies.forbid
+    path: app/services/tag_hashtag_data_source.rb
+    message: services must not depend on controllers
+    evidence: TagHashtagDataSource references TagsController
+    verdict: unjudged
+  2970844f961abf1c0814207a:
+    rule: dependencies.forbid
+    path: app/services/category/hierarchical_search.rb
+    message: services must not depend on controllers
+    evidence: Category::HierarchicalSearch references CategoriesController::MAX_CATEGORIES_LIMIT
+    verdict: unjudged
+  32927b922e5d3b826934150e:
+    rule: dependencies.forbid
+    path: app/services/user_api_key/device_auth.rb
+    message: services must not depend on controllers
+    evidence: UserApiKey::DeviceAuth::ALLOWED_PADDING_MODES references UserApiKeysController::ALLOWED_PADDING_MODES
+    verdict: unjudged
+  8564ef3f0ad87ef728a3bb7f:
+    rule: dependencies.forbid
+    path: app/models/site_setting.rb
+    message: models must not depend on controllers
+    evidence: SiteSetting references ListController
+    verdict: unjudged
+  bb75fc00947ceb0f3a9ac332:
+    rule: dependencies.forbid
+    path: app/services/user_api_key/device_auth.rb
+    message: services must not depend on controllers
+    evidence: UserApiKey::DeviceAuth::AUTH_API_VERSION references UserApiKeysController::AUTH_API_VERSION
+    verdict: unjudged
+  e99ec3f3a5fa34aafc3ff6a8:
+    rule: dependencies.forbid
+    path: app/models/topic.rb
+    message: models must not depend on controllers
+    evidence: Topic references ListController
+    verdict: unjudged
+  ec8234e285036f721bbd0108:
+    rule: dependencies.forbid
+    path: app/models/translation_override.rb
+    message: models must not depend on controllers
+    evidence: TranslationOverride references ExtraLocalesController
+    verdict: unjudged
+  f3f86b9efc2a947b97fce039:
+    rule: dependencies.forbid
+    path: app/services/tags/search.rb
+    message: services must not depend on controllers
+    evidence: Tags::Search references TagsController
+    verdict: unjudged

--- a/test/torture/discourse/expected.yml
+++ b/test/torture/discourse/expected.yml
@@ -8,52 +8,61 @@ diagnostics:
     path: app/services/user_authenticator.rb
     message: services must not depend on controllers
     evidence: UserAuthenticator references Users::OmniauthCallbacksController
-    verdict: unjudged
+    verdict: true_positive
+    note: user_authenticator.rb:7 passes Users::OmniauthCallbacksController as the default authenticator_finder
   1c39cf10a18a1664f58bd15f:
     rule: dependencies.forbid
     path: app/services/tag_hashtag_data_source.rb
     message: services must not depend on controllers
     evidence: TagHashtagDataSource references TagsController
-    verdict: unjudged
+    verdict: true_positive
+    note: tag_hashtag_data_source.rb:75 and :97 return TagsController as the data source's controller
   2970844f961abf1c0814207a:
     rule: dependencies.forbid
     path: app/services/category/hierarchical_search.rb
     message: services must not depend on controllers
     evidence: Category::HierarchicalSearch references CategoriesController::MAX_CATEGORIES_LIMIT
-    verdict: unjudged
+    verdict: true_positive
+    note: hierarchical_search.rb:16 reads CategoriesController::MAX_CATEGORIES_LIMIT for its limit
   32927b922e5d3b826934150e:
     rule: dependencies.forbid
     path: app/services/user_api_key/device_auth.rb
     message: services must not depend on controllers
     evidence: UserApiKey::DeviceAuth::ALLOWED_PADDING_MODES references UserApiKeysController::ALLOWED_PADDING_MODES
-    verdict: unjudged
+    verdict: true_positive
+    note: device_auth.rb:20 aliases UserApiKeysController::ALLOWED_PADDING_MODES
   8564ef3f0ad87ef728a3bb7f:
     rule: dependencies.forbid
     path: app/models/site_setting.rb
     message: models must not depend on controllers
     evidence: SiteSetting references ListController
-    verdict: unjudged
+    verdict: true_positive
+    note: site_setting.rb:221 calls ListController.best_period_with_topics_for
   bb75fc00947ceb0f3a9ac332:
     rule: dependencies.forbid
     path: app/services/user_api_key/device_auth.rb
     message: services must not depend on controllers
     evidence: UserApiKey::DeviceAuth::AUTH_API_VERSION references UserApiKeysController::AUTH_API_VERSION
-    verdict: unjudged
+    verdict: true_positive
+    note: device_auth.rb:19 aliases UserApiKeysController::AUTH_API_VERSION
   e99ec3f3a5fa34aafc3ff6a8:
     rule: dependencies.forbid
     path: app/models/topic.rb
     message: models must not depend on controllers
     evidence: Topic references ListController
-    verdict: unjudged
+    verdict: true_positive
+    note: topic.rb:621 calls ListController.best_period_for
   ec8234e285036f721bbd0108:
     rule: dependencies.forbid
     path: app/models/translation_override.rb
     message: models must not depend on controllers
     evidence: TranslationOverride references ExtraLocalesController
-    verdict: unjudged
+    verdict: true_positive
+    note: translation_override.rb:99 calls ExtraLocalesController.clear_cache!
   f3f86b9efc2a947b97fce039:
     rule: dependencies.forbid
     path: app/services/tags/search.rb
     message: services must not depend on controllers
     evidence: Tags::Search references TagsController
-    verdict: unjudged
+    verdict: true_positive
+    note: search.rb:120 calls TagsController.tag_counts_json

--- a/test/torture/fizzy/expected.yml
+++ b/test/torture/fizzy/expected.yml
@@ -4,3 +4,32 @@ rules:
   concerns.independence: 1
   dependencies.forbid: 1
   naming.forbidden: 2
+diagnostics:
+  2d3fec0d3ef563de7940a03b:
+    rule: concerns.independence
+    path: app/models/concerns/storage/tracked.rb
+    message: Storage::Tracked must not reference its includer Board
+    evidence: Storage::Tracked references Board
+    verdict: unjudged
+  8e8ffd2648cbbe5a0d95fd0c:
+    rule: dependencies.forbid
+    path: app/models/webhook.rb
+    message: models must not depend on controllers
+    evidence: Webhook references ApplicationController
+    verdict: unjudged
+  9ceeb430e0d66cba7d946670:
+    rule: naming.forbidden
+    path: app/mailers/concerns/mailers/unsubscribable.rb
+    message: 'Mailers::Unsubscribable must not define #set_unsubscribe_headers: use
+      attr_ readers and writers or plain names, not get_/set_'
+    evidence: Mailers::Unsubscribable defines instance method set_unsubscribe_headers
+      (matches /\A(get|set)_/)
+    verdict: unjudged
+  c6a90bb06c761f98c10643d5:
+    rule: naming.forbidden
+    path: app/models/notification/bundle.rb
+    message: 'Notification::Bundle must not define #set_default_window: use attr_
+      readers and writers or plain names, not get_/set_'
+    evidence: Notification::Bundle defines instance method set_default_window (matches
+      /\A(get|set)_/)
+    verdict: unjudged

--- a/test/torture/fizzy/expected.yml
+++ b/test/torture/fizzy/expected.yml
@@ -10,13 +10,15 @@ diagnostics:
     path: app/models/concerns/storage/tracked.rb
     message: Storage::Tracked must not reference its includer Board
     evidence: Storage::Tracked references Board
-    verdict: unjudged
+    verdict: true_positive
+    note: tracked.rb:32 calls Board.find_by inside track_board_transfer, and board.rb:2 includes ::Storage::Tracked; the concern names its own includer
   8e8ffd2648cbbe5a0d95fd0c:
     rule: dependencies.forbid
     path: app/models/webhook.rb
     message: models must not depend on controllers
     evidence: Webhook references ApplicationController
-    verdict: unjudged
+    verdict: true_positive
+    note: webhook.rb:53 builds ApplicationController.renderer; the canonical Rails way to render off-request, still a model reaching a controller under the vanilla preset
   9ceeb430e0d66cba7d946670:
     rule: naming.forbidden
     path: app/mailers/concerns/mailers/unsubscribable.rb
@@ -24,7 +26,8 @@ diagnostics:
       attr_ readers and writers or plain names, not get_/set_'
     evidence: Mailers::Unsubscribable defines instance method set_unsubscribe_headers
       (matches /\A(get|set)_/)
-    verdict: unjudged
+    verdict: true_positive
+    note: unsubscribable.rb:8 defines set_unsubscribe_headers, a set_ prefix the ruby_conventions preset forbids
   c6a90bb06c761f98c10643d5:
     rule: naming.forbidden
     path: app/models/notification/bundle.rb
@@ -32,4 +35,5 @@ diagnostics:
       readers and writers or plain names, not get_/set_'
     evidence: Notification::Bundle defines instance method set_default_window (matches
       /\A(get|set)_/)
-    verdict: unjudged
+    verdict: true_positive
+    note: bundle.rb:60 defines set_default_window, a set_ prefix the ruby_conventions preset forbids

--- a/test/torture/mastodon/expected.yml
+++ b/test/torture/mastodon/expected.yml
@@ -2,3 +2,88 @@
 sha: 163f96cee4dea23365bff9b433871e68d20d9ee7
 rules:
   dependencies.forbid: 14
+diagnostics:
+  0a0948434731f34b9bf5bda6:
+    rule: dependencies.forbid
+    path: app/services/reblog_service.rb
+    message: services must not depend on controllers
+    evidence: ReblogService includes Authorization
+    verdict: unjudged
+  0c75815b1ddfa5f025648646:
+    rule: dependencies.forbid
+    path: app/models/trends/preview_card_batch.rb
+    message: models must not depend on controllers
+    evidence: Trends::PreviewCardBatch includes Authorization
+    verdict: unjudged
+  1807c39bbe582b3becf4da3f:
+    rule: dependencies.forbid
+    path: app/services/vote_service.rb
+    message: services must not depend on controllers
+    evidence: VoteService includes Authorization
+    verdict: unjudged
+  40831f7d2c7c0d44dee1a4a6:
+    rule: dependencies.forbid
+    path: app/models/admin/base_action.rb
+    message: models must not depend on controllers
+    evidence: Admin::BaseAction includes Authorization
+    verdict: unjudged
+  5ed1b4e211e1150cff49438c:
+    rule: dependencies.forbid
+    path: app/models/form/base_batch.rb
+    message: models must not depend on controllers
+    evidence: Form::BaseBatch includes AccountableConcern
+    verdict: unjudged
+  69cf01e1dac8242fdc98dd8e:
+    rule: dependencies.forbid
+    path: app/services/favourite_service.rb
+    message: services must not depend on controllers
+    evidence: FavouriteService includes Authorization
+    verdict: unjudged
+  81b8c0c599d5d9635580fb45:
+    rule: dependencies.forbid
+    path: app/models/form/status_filter_batch_action.rb
+    message: models must not depend on controllers
+    evidence: Form::StatusFilterBatchAction includes AccountableConcern
+    verdict: unjudged
+  9bffdcf1245c71493ab4b975:
+    rule: dependencies.forbid
+    path: app/models/form/status_filter_batch_action.rb
+    message: models must not depend on controllers
+    evidence: Form::StatusFilterBatchAction includes Authorization
+    verdict: unjudged
+  9ebaf9ae2f9b04cffc1d5e35:
+    rule: dependencies.forbid
+    path: app/models/trends/status_batch.rb
+    message: models must not depend on controllers
+    evidence: Trends::StatusBatch includes Authorization
+    verdict: unjudged
+  a78248d6e2bf7a1eeba4d64c:
+    rule: dependencies.forbid
+    path: app/services/resolve_url_service.rb
+    message: services must not depend on controllers
+    evidence: ResolveURLService includes Authorization
+    verdict: unjudged
+  c7e09e14df1d7d2e5dd0bc78:
+    rule: dependencies.forbid
+    path: app/models/trends/tag_batch.rb
+    message: models must not depend on controllers
+    evidence: Trends::TagBatch includes Authorization
+    verdict: unjudged
+  d8c3d18c616623d0566fbf17:
+    rule: dependencies.forbid
+    path: app/models/trends/preview_card_provider_batch.rb
+    message: models must not depend on controllers
+    evidence: Trends::PreviewCardProviderBatch includes Authorization
+    verdict: unjudged
+  dee207039c0a0a86467751fe:
+    rule: dependencies.forbid
+    path: app/models/admin/base_action.rb
+    message: models must not depend on controllers
+    evidence: Admin::BaseAction includes AccountableConcern
+    verdict: unjudged
+  f0a05c6a011d509d0a6a26ea:
+    rule: dependencies.forbid
+    path: app/models/form/base_batch.rb
+    message: models must not depend on controllers
+    evidence: Form::BaseBatch includes Authorization
+    verdict: unjudged

--- a/test/torture/mastodon/expected.yml
+++ b/test/torture/mastodon/expected.yml
@@ -8,82 +8,96 @@ diagnostics:
     path: app/services/reblog_service.rb
     message: services must not depend on controllers
     evidence: ReblogService includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   0c75815b1ddfa5f025648646:
     rule: dependencies.forbid
     path: app/models/trends/preview_card_batch.rb
     message: models must not depend on controllers
     evidence: Trends::PreviewCardBatch includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   1807c39bbe582b3becf4da3f:
     rule: dependencies.forbid
     path: app/services/vote_service.rb
     message: services must not depend on controllers
     evidence: VoteService includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   40831f7d2c7c0d44dee1a4a6:
     rule: dependencies.forbid
     path: app/models/admin/base_action.rb
     message: models must not depend on controllers
     evidence: Admin::BaseAction includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   5ed1b4e211e1150cff49438c:
     rule: dependencies.forbid
     path: app/models/form/base_batch.rb
     message: models must not depend on controllers
     evidence: Form::BaseBatch includes AccountableConcern
-    verdict: unjudged
+    verdict: true_positive
+    note: AccountableConcern lives in app/controllers/concerns/accountable_concern.rb, inside the controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   69cf01e1dac8242fdc98dd8e:
     rule: dependencies.forbid
     path: app/services/favourite_service.rb
     message: services must not depend on controllers
     evidence: FavouriteService includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   81b8c0c599d5d9635580fb45:
     rule: dependencies.forbid
     path: app/models/form/status_filter_batch_action.rb
     message: models must not depend on controllers
     evidence: Form::StatusFilterBatchAction includes AccountableConcern
-    verdict: unjudged
+    verdict: true_positive
+    note: AccountableConcern lives in app/controllers/concerns/accountable_concern.rb, inside the controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   9bffdcf1245c71493ab4b975:
     rule: dependencies.forbid
     path: app/models/form/status_filter_batch_action.rb
     message: models must not depend on controllers
     evidence: Form::StatusFilterBatchAction includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   9ebaf9ae2f9b04cffc1d5e35:
     rule: dependencies.forbid
     path: app/models/trends/status_batch.rb
     message: models must not depend on controllers
     evidence: Trends::StatusBatch includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   a78248d6e2bf7a1eeba4d64c:
     rule: dependencies.forbid
     path: app/services/resolve_url_service.rb
     message: services must not depend on controllers
     evidence: ResolveURLService includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   c7e09e14df1d7d2e5dd0bc78:
     rule: dependencies.forbid
     path: app/models/trends/tag_batch.rb
     message: models must not depend on controllers
     evidence: Trends::TagBatch includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   d8c3d18c616623d0566fbf17:
     rule: dependencies.forbid
     path: app/models/trends/preview_card_provider_batch.rb
     message: models must not depend on controllers
     evidence: Trends::PreviewCardProviderBatch includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   dee207039c0a0a86467751fe:
     rule: dependencies.forbid
     path: app/models/admin/base_action.rb
     message: models must not depend on controllers
     evidence: Admin::BaseAction includes AccountableConcern
-    verdict: unjudged
+    verdict: true_positive
+    note: AccountableConcern lives in app/controllers/concerns/accountable_concern.rb, inside the controllers component; the include is real, the cure is moving the shared concern out of app/controllers
   f0a05c6a011d509d0a6a26ea:
     rule: dependencies.forbid
     path: app/models/form/base_batch.rb
     message: models must not depend on controllers
     evidence: Form::BaseBatch includes Authorization
-    verdict: unjudged
+    verdict: true_positive
+    note: Authorization lives in app/controllers/concerns/authorization.rb, inside the rails preset's controllers component; the include is real, the cure is moving the shared concern out of app/controllers

--- a/test/torture/run.rb
+++ b/test/torture/run.rb
@@ -2,10 +2,16 @@
 # frozen_string_literal: true
 
 # Runs ArchSpec against a large open source Rails app pinned to a known
-# commit, then compares per-rule diagnostic counts against a snapshot.
+# commit, then compares every diagnostic against the recorded set in
+# expected.yml: one entry per diagnostic with the verdict a person gave it.
 #
 #   ruby test/torture/run.rb discourse
 #   ruby test/torture/run.rb mastodon --update
+#
+# A run fails when the per-rule counts move, when a diagnostic appears that
+# the record does not carry, or when a true positive disappears. --update
+# records new diagnostics as unjudged and keeps every verdict already
+# written; it refuses to drop a true positive, which only a hand edit may do.
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
 
@@ -14,6 +20,7 @@ require 'fileutils'
 require 'json'
 require 'stringio'
 require 'yaml'
+require_relative 'snapshot'
 
 APPS = {
   'discourse' => {
@@ -62,8 +69,8 @@ elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
 abort "archspec crashed on #{app_name} (exit #{status})" unless [0, 1].include?(status)
 
 report = JSON.parse(output.string)
-counts = report.fetch('violations').group_by { |violation| violation.fetch('rule') }
-               .transform_values(&:size).sort.to_h
+violations = report.fetch('violations')
+counts = TortureSnapshot.counts_for(violations)
 
 puts format('%s @ %s: %d files, %d constants, %d facts in %.1fs',
             app_name, app.fetch(:sha)[0, 12], report.fetch('files'),
@@ -71,28 +78,59 @@ puts format('%s @ %s: %d files, %d constants, %d facts in %.1fs',
 counts.each { |rule, count| puts format('  %-40s %d', rule, count) }
 puts '  no violations' if counts.empty?
 
+def describe(entry, label)
+  format('  %-24s %-28s %s  %s', label, entry.fetch('rule'), entry.fetch('path'), entry.fetch('message'))
+end
+
+recorded = File.exist?(expected_path) ? TortureSnapshot.load(expected_path) : nil
+
 if update
-  File.write(expected_path, { 'sha' => app.fetch(:sha), 'rules' => counts }.to_yaml)
+  snapshot, retained = TortureSnapshot.update(recorded || {}, violations, sha: app.fetch(:sha))
+  unless retained.empty?
+    puts 'refusing to drop true positives no longer reported; edit the record by hand:'
+    recorded.fetch('diagnostics').each { |id, entry| puts describe(entry, id) if retained.include?(entry) }
+    exit 1
+  end
+  File.write(expected_path, snapshot.to_yaml)
   puts "wrote #{expected_path}"
   exit 0
 end
 
-unless File.exist?(expected_path)
+if recorded.nil?
   puts "no snapshot at #{expected_path}; run with --update to record one"
   exit 0
 end
 
-expected = YAML.safe_load_file(expected_path)
-abort 'snapshot SHA does not match pinned SHA; re-record with --update' if expected.fetch('sha') != app.fetch(:sha)
+abort 'snapshot SHA does not match pinned SHA; re-record with --update' if recorded.fetch('sha') != app.fetch(:sha)
 
-if expected.fetch('rules') == counts
-  puts 'matches snapshot'
-else
+if TortureSnapshot.legacy?(recorded)
+  puts 'record carries counts only; run with --update to record each diagnostic'
+end
+
+result = TortureSnapshot.compare(recorded, violations)
+
+unless result.added.empty?
+  puts 'added (not in the record):'
+  result.added.each { |id, entry| puts describe(entry, id) }
+end
+unless result.removed.empty?
+  puts 'removed (in the record, not reported):'
+  result.removed.each { |entry| puts describe(entry, entry.fetch('verdict')) }
+end
+puts "#{result.improved.size} false positive(s) no longer reported" unless result.improved.empty?
+
+if result.counts_changed
   puts 'MISMATCH against snapshot:'
-  (expected.fetch('rules').keys | counts.keys).sort.each do |rule|
-    was = expected.fetch('rules').fetch(rule, 0)
+  (recorded.fetch('rules').keys | counts.keys).sort.each do |rule|
+    was = recorded.fetch('rules').fetch(rule, 0)
     now = counts.fetch(rule, 0)
     puts format('  %-40s %d -> %d', rule, was, now) if was != now
   end
+end
+
+if result.pass?
+  puts 'matches snapshot'
+else
+  puts "FAILED: #{result.failures.join('; ')}"
   exit 1
 end

--- a/test/torture/run.rb
+++ b/test/torture/run.rb
@@ -85,13 +85,13 @@ end
 recorded = File.exist?(expected_path) ? TortureSnapshot.load(expected_path) : nil
 
 if update
-  snapshot, retained = TortureSnapshot.update(recorded || {}, violations, sha: app.fetch(:sha))
-  unless retained.empty?
+  update = TortureSnapshot.update(recorded || {}, violations, sha: app.fetch(:sha))
+  if update.refused?
     puts 'refusing to drop true positives no longer reported; edit the record by hand:'
-    recorded.fetch('diagnostics').each { |id, entry| puts describe(entry, id) if retained.include?(entry) }
+    recorded.fetch('diagnostics').each { |id, entry| puts describe(entry, id) if update.retained.include?(entry) }
     exit 1
   end
-  File.write(expected_path, snapshot.to_yaml)
+  File.write(expected_path, update.snapshot.to_yaml)
   puts "wrote #{expected_path}"
   exit 0
 end

--- a/test/torture/snapshot.rb
+++ b/test/torture/snapshot.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+# The recorded set of diagnostics for a pinned torture app: one entry per
+# diagnostic keyed by its todo fingerprint, each carrying a verdict a person
+# wrote. The per-rule counts are derived from the entries and checked on every
+# run, so the gate a release relied on only gets stronger. Two violations at
+# different lines of one file can share a fingerprint; the counts stay per
+# violation, as the release gate always counted them, while the entries are
+# per fingerprint.
+module TortureSnapshot
+  VERDICTS = %w[true_positive false_positive unjudged].freeze
+  FIELDS = %w[rule path message evidence].freeze
+
+  Result = Struct.new(:counts_changed, :added, :removed, :improved, keyword_init: true) do
+    def failures
+      failures = []
+      failures << 'per-rule counts moved' if counts_changed
+      failures << "#{added.size} diagnostic(s) not in the record" unless added.empty?
+      lost = removed.select { |entry| entry.fetch('verdict') == 'true_positive' }
+      failures << "#{lost.size} true positive(s) gone" unless lost.empty?
+      failures
+    end
+
+    def pass?
+      failures.empty?
+    end
+  end
+
+  module_function
+
+  def load(path)
+    data = YAML.safe_load_file(path)
+    entries = data.fetch('diagnostics', {})
+    entries.each do |id, entry|
+      verdict = entry.fetch('verdict', nil)
+      next if VERDICTS.include?(verdict)
+
+      raise ArgumentError, "#{path}: #{id} has verdict #{verdict.inspect}, expected one of #{VERDICTS.join(', ')}"
+    end
+    data
+  end
+
+  def entries_for(violations)
+    violations.each_with_object({}) do |violation, entries|
+      entries[violation.fetch('id')] = FIELDS.to_h { |field| [field, violation.fetch(field)] }
+    end.sort.to_h
+  end
+
+  def counts_for(violations)
+    violations.group_by { |violation| violation.fetch('rule') }.transform_values(&:size).sort.to_h
+  end
+
+  def compare(recorded, violations)
+    live = entries_for(violations)
+    counts_changed = recorded.fetch('rules') != counts_for(violations)
+    return Result.new(counts_changed: counts_changed, added: {}, removed: [], improved: []) if legacy?(recorded)
+
+    recorded_entries = recorded.fetch('diagnostics')
+    added = live.reject { |id, _| recorded_entries.key?(id) }
+    removed = recorded_entries.reject { |id, _| live.key?(id) }
+    Result.new(
+      counts_changed: counts_changed,
+      added: added,
+      removed: removed.values,
+      improved: removed.values.select { |entry| entry.fetch('verdict') == 'false_positive' }
+    )
+  end
+
+  def update(recorded, violations, sha:)
+    live = entries_for(violations)
+    previous = recorded.fetch('diagnostics', {})
+    kept = previous.select { |id, entry| live.key?(id) || entry.fetch('verdict') == 'true_positive' }
+    retained_true_positives = kept.reject { |id, _| live.key?(id) }
+    return [nil, retained_true_positives.values] unless retained_true_positives.empty?
+
+    entries = live.to_h do |id, entry|
+      judged = previous.fetch(id, {})
+      merged = entry.merge('verdict' => judged.fetch('verdict', 'unjudged'))
+      merged['note'] = judged['note'] if judged.key?('note')
+      [id, merged]
+    end
+    [{ 'sha' => sha, 'rules' => counts_for(violations), 'diagnostics' => entries }, []]
+  end
+
+  def legacy?(recorded)
+    !recorded.key?('diagnostics')
+  end
+end

--- a/test/torture/snapshot.rb
+++ b/test/torture/snapshot.rb
@@ -13,6 +13,12 @@ module TortureSnapshot
   VERDICTS = %w[true_positive false_positive unjudged].freeze
   FIELDS = %w[rule path message evidence].freeze
 
+  Update = Struct.new(:snapshot, :retained, keyword_init: true) do
+    def refused?
+      !retained.empty?
+    end
+  end
+
   Result = Struct.new(:counts_changed, :added, :removed, :improved, keyword_init: true) do
     def failures
       failures = []
@@ -32,9 +38,18 @@ module TortureSnapshot
 
   def load(path)
     data = YAML.safe_load_file(path)
+    raise ArgumentError, "#{path}: expected a mapping with sha and rules" unless data.is_a?(Hash) && data.key?('sha') && data['rules'].is_a?(Hash)
+
     entries = data.fetch('diagnostics', {})
+    raise ArgumentError, "#{path}: diagnostics must be a mapping keyed by fingerprint" unless entries.is_a?(Hash)
+
     entries.each do |id, entry|
-      verdict = entry.fetch('verdict', nil)
+      raise ArgumentError, "#{path}: #{id} is not a mapping" unless entry.is_a?(Hash)
+
+      missing = (FIELDS + ['verdict']).reject { |field| entry.key?(field) }
+      raise ArgumentError, "#{path}: #{id} is missing #{missing.join(', ')}" unless missing.empty?
+
+      verdict = entry.fetch('verdict')
       next if VERDICTS.include?(verdict)
 
       raise ArgumentError, "#{path}: #{id} has verdict #{verdict.inspect}, expected one of #{VERDICTS.join(', ')}"
@@ -73,7 +88,7 @@ module TortureSnapshot
     previous = recorded.fetch('diagnostics', {})
     kept = previous.select { |id, entry| live.key?(id) || entry.fetch('verdict') == 'true_positive' }
     retained_true_positives = kept.reject { |id, _| live.key?(id) }
-    return [nil, retained_true_positives.values] unless retained_true_positives.empty?
+    return Update.new(snapshot: nil, retained: retained_true_positives.values) unless retained_true_positives.empty?
 
     entries = live.to_h do |id, entry|
       judged = previous.fetch(id, {})
@@ -81,7 +96,7 @@ module TortureSnapshot
       merged['note'] = judged['note'] if judged.key?('note')
       [id, merged]
     end
-    [{ 'sha' => sha, 'rules' => counts_for(violations), 'diagnostics' => entries }, []]
+    Update.new(snapshot: { 'sha' => sha, 'rules' => counts_for(violations), 'diagnostics' => entries }, retained: [])
   end
 
   def legacy?(recorded)

--- a/test/torture_snapshot_test.rb
+++ b/test/torture_snapshot_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative 'torture/snapshot'
+
+class TortureSnapshotTest < Minitest::Test
+  SHA = 'abc123'
+
+  def test_entries_are_keyed_by_fingerprint_and_sorted
+    entries = TortureSnapshot.entries_for([violation('b'), violation('a')])
+
+    assert_equal %w[a b], entries.keys
+    assert_equal TortureSnapshot::FIELDS, entries.fetch('a').keys
+  end
+
+  def test_update_records_new_diagnostics_as_unjudged_and_keeps_verdicts
+    recorded = record('a' => 'true_positive', 'b' => 'false_positive')
+    recorded.fetch('diagnostics').fetch('a')['note'] = 'real'
+    snapshot, retained = TortureSnapshot.update(recorded, [violation('a'), violation('b'), violation('c')], sha: SHA)
+
+    assert_empty retained
+    assert_equal 'true_positive', snapshot.dig('diagnostics', 'a', 'verdict')
+    assert_equal 'real', snapshot.dig('diagnostics', 'a', 'note')
+    assert_equal 'false_positive', snapshot.dig('diagnostics', 'b', 'verdict')
+    assert_equal 'unjudged', snapshot.dig('diagnostics', 'c', 'verdict')
+    assert_equal({ 'dependencies.forbid' => 3 }, snapshot.fetch('rules'))
+  end
+
+  def test_update_drops_unjudged_and_false_positives_but_refuses_true_positives
+    recorded = record('a' => 'unjudged', 'b' => 'false_positive')
+    snapshot, retained = TortureSnapshot.update(recorded, [], sha: SHA)
+
+    assert_empty retained
+    assert_empty snapshot.fetch('diagnostics')
+
+    recorded = record('a' => 'true_positive')
+    snapshot, retained = TortureSnapshot.update(recorded, [], sha: SHA)
+
+    assert_nil snapshot
+    assert_equal ['true_positive'], retained.map { |entry| entry.fetch('verdict') }
+  end
+
+  def test_update_migrates_a_counts_only_record
+    legacy = { 'sha' => SHA, 'rules' => { 'dependencies.forbid' => 1 } }
+    snapshot, = TortureSnapshot.update(legacy, [violation('a')], sha: SHA)
+
+    assert_equal 'unjudged', snapshot.dig('diagnostics', 'a', 'verdict')
+    assert_equal legacy.fetch('rules'), snapshot.fetch('rules')
+  end
+
+  def test_compare_fails_on_unrecorded_additions_and_lost_true_positives
+    recorded = record('a' => 'true_positive', 'b' => 'false_positive')
+
+    result = TortureSnapshot.compare(recorded, [violation('a'), violation('b')])
+    assert result.pass?
+
+    result = TortureSnapshot.compare(recorded, [violation('a'), violation('c')])
+    refute result.pass?
+    assert_equal %w[c], result.added.keys
+
+    result = TortureSnapshot.compare(recorded, [violation('b')])
+    refute result.pass?
+    assert_includes result.failures, '1 true positive(s) gone'
+  end
+
+  def test_counts_stay_per_violation_when_two_share_a_fingerprint
+    violations = [violation('a').merge('line' => 3), violation('a').merge('line' => 9)]
+    snapshot, = TortureSnapshot.update({}, violations, sha: SHA)
+
+    assert_equal({ 'dependencies.forbid' => 2 }, snapshot.fetch('rules'))
+    assert_equal %w[a], snapshot.fetch('diagnostics').keys
+  end
+
+  def test_compare_treats_a_vanished_false_positive_as_an_improvement
+    recorded = record('a' => 'true_positive', 'b' => 'false_positive', 'c' => 'unjudged')
+    recorded['rules'] = { 'dependencies.forbid' => 1 }
+
+    result = TortureSnapshot.compare(recorded, [violation('a')])
+
+    assert result.pass?
+    assert_equal 1, result.improved.size
+  end
+
+  def test_compare_checks_counts_only_against_a_counts_only_record
+    legacy = { 'sha' => SHA, 'rules' => { 'dependencies.forbid' => 1 } }
+
+    assert TortureSnapshot.compare(legacy, [violation('a')]).pass?
+    refute TortureSnapshot.compare(legacy, []).pass?
+  end
+
+  def test_load_rejects_an_unknown_verdict
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'expected.yml')
+      File.write(path, record('a' => 'maybe').to_yaml)
+
+      assert_raises(ArgumentError) { TortureSnapshot.load(path) }
+    end
+  end
+
+  private
+
+  def violation(id, rule: 'dependencies.forbid')
+    { 'id' => id, 'rule' => rule, 'path' => "app/#{id}.rb", 'message' => "#{id} breaks", 'evidence' => "references #{id}", 'line' => 3 }
+  end
+
+  def record(verdicts)
+    entries = verdicts.to_h do |id, verdict|
+      [id, TortureSnapshot.entries_for([violation(id)]).fetch(id).merge('verdict' => verdict)]
+    end
+    { 'sha' => SHA, 'rules' => TortureSnapshot.counts_for(verdicts.keys.map { |id| violation(id) }), 'diagnostics' => entries }
+  end
+end

--- a/test/torture_snapshot_test.rb
+++ b/test/torture_snapshot_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'tmpdir'
 require_relative 'torture/snapshot'
 
 class TortureSnapshotTest < Minitest::Test
@@ -16,9 +17,10 @@ class TortureSnapshotTest < Minitest::Test
   def test_update_records_new_diagnostics_as_unjudged_and_keeps_verdicts
     recorded = record('a' => 'true_positive', 'b' => 'false_positive')
     recorded.fetch('diagnostics').fetch('a')['note'] = 'real'
-    snapshot, retained = TortureSnapshot.update(recorded, [violation('a'), violation('b'), violation('c')], sha: SHA)
+    update = TortureSnapshot.update(recorded, [violation('a'), violation('b'), violation('c')], sha: SHA)
+    snapshot = update.snapshot
 
-    assert_empty retained
+    refute update.refused?
     assert_equal 'true_positive', snapshot.dig('diagnostics', 'a', 'verdict')
     assert_equal 'real', snapshot.dig('diagnostics', 'a', 'note')
     assert_equal 'false_positive', snapshot.dig('diagnostics', 'b', 'verdict')
@@ -28,21 +30,22 @@ class TortureSnapshotTest < Minitest::Test
 
   def test_update_drops_unjudged_and_false_positives_but_refuses_true_positives
     recorded = record('a' => 'unjudged', 'b' => 'false_positive')
-    snapshot, retained = TortureSnapshot.update(recorded, [], sha: SHA)
+    update = TortureSnapshot.update(recorded, [], sha: SHA)
 
-    assert_empty retained
-    assert_empty snapshot.fetch('diagnostics')
+    refute update.refused?
+    assert_empty update.snapshot.fetch('diagnostics')
 
     recorded = record('a' => 'true_positive')
-    snapshot, retained = TortureSnapshot.update(recorded, [], sha: SHA)
+    update = TortureSnapshot.update(recorded, [], sha: SHA)
 
-    assert_nil snapshot
-    assert_equal ['true_positive'], retained.map { |entry| entry.fetch('verdict') }
+    assert update.refused?
+    assert_nil update.snapshot
+    assert_equal ['true_positive'], update.retained.map { |entry| entry.fetch('verdict') }
   end
 
   def test_update_migrates_a_counts_only_record
     legacy = { 'sha' => SHA, 'rules' => { 'dependencies.forbid' => 1 } }
-    snapshot, = TortureSnapshot.update(legacy, [violation('a')], sha: SHA)
+    snapshot = TortureSnapshot.update(legacy, [violation('a')], sha: SHA).snapshot
 
     assert_equal 'unjudged', snapshot.dig('diagnostics', 'a', 'verdict')
     assert_equal legacy.fetch('rules'), snapshot.fetch('rules')
@@ -65,7 +68,7 @@ class TortureSnapshotTest < Minitest::Test
 
   def test_counts_stay_per_violation_when_two_share_a_fingerprint
     violations = [violation('a').merge('line' => 3), violation('a').merge('line' => 9)]
-    snapshot, = TortureSnapshot.update({}, violations, sha: SHA)
+    snapshot = TortureSnapshot.update({}, violations, sha: SHA).snapshot
 
     assert_equal({ 'dependencies.forbid' => 2 }, snapshot.fetch('rules'))
     assert_equal %w[a], snapshot.fetch('diagnostics').keys
@@ -108,5 +111,18 @@ class TortureSnapshotTest < Minitest::Test
       [id, TortureSnapshot.entries_for([violation(id)]).fetch(id).merge('verdict' => verdict)]
     end
     { 'sha' => SHA, 'rules' => TortureSnapshot.counts_for(verdicts.keys.map { |id| violation(id) }), 'diagnostics' => entries }
+  end
+
+  def test_load_names_the_file_and_entry_when_the_shape_is_wrong
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'expected.yml')
+      File.write(path, { 'sha' => SHA, 'rules' => {}, 'diagnostics' => { 'a' => { 'rule' => 'x' } } }.to_yaml)
+      error = assert_raises(ArgumentError) { TortureSnapshot.load(path) }
+      assert_match(/expected\.yml: a is missing path, message, evidence, verdict/, error.message)
+
+      File.write(path, { 'sha' => SHA, 'rules' => {}, 'diagnostics' => [] }.to_yaml)
+      error = assert_raises(ArgumentError) { TortureSnapshot.load(path) }
+      assert_match(/diagnostics must be a mapping/, error.message)
+    end
   end
 end


### PR DESCRIPTION
The torture expectations now say which diagnostics are right, not only how many there are. Each `expected.yml` lists every diagnostic by its todo fingerprint (rule, path, message, evidence, no line numbers) with a verdict of `true_positive`, `false_positive` or `unjudged` and a note naming the evidence; the `sha` pin and the per-rule counts stay and are still checked, so the release gate only gets stronger.

`run.rb` reports added and removed entries, fails on a count mismatch, on any removed true positive, and on any addition nobody recorded; `--update` appends new entries as `unjudged`, drops only unjudged or false-positive ones, and refuses to drop a true positive. Verdicts are written by a person, never by the tool.

Stacked on #10; the incremental diff is https://github.com/misabegovic/archspec/compare/up/01-except-and-class-protocols...up/02-torture-verdicts. All 27 diagnostics across Fizzy, Discourse and Mastodon are judged against the code (all true positives under the torture specs as written; the 14 Mastodon entries come from concerns that live under `app/controllers`, which you may prefer to call a narrower component), counts unchanged, and a unit test covers the snapshot diffing.
